### PR TITLE
Remove extra "e" in include directive.

### DIFF
--- a/src/windows/stack_traits.cpp
+++ b/src/windows/stack_traits.cpp
@@ -22,7 +22,7 @@ extern "C" {
 #include <boost/context/detail/config.hpp>
 #include <boost/thread.hpp>
 
-#include <boost/econtext/stack_context.hpp>
+#include <boost/context/stack_context.hpp>
 
 // x86_64
 // test x86_64 before i386 because icc might


### PR DESCRIPTION
Some typo or mistake introduced while resolving merge conclicts.maybe. This breaks windows compilation only.