### PR TITLE
Changes required for aarch64 support in boost::context.

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -222,6 +222,37 @@ alias asm_context_sources
    ;
 
 # ARM64
+# ARM64/SYSV/ELF
+alias asm_context_sources
+   : [ make asm/make_arm64_aapcs_elf_gas.o : asm/make_arm64_aapcs_elf_gas.S : @gas64 ]
+     [ make asm/jump_arm64_aapcs_elf_gas.o : asm/jump_arm64_aapcs_elf_gas.S : @gas64 ]
+   : <abi>sysv
+     <address-model>64
+     <architecture>arm
+     <binary-format>elf
+   ;
+
+alias asm_context_sources
+   : asm/make_arm64_aapcs_elf_gas.S
+     asm/jump_arm64_aapcs_elf_gas.S
+   : <abi>sysv
+     <address-model>64
+     <architecture>arm
+     <binary-format>elf
+     <toolset>clang
+   ;
+
+alias asm_context_sources
+   : asm/make_arm64_aapcs_elf_gas.S
+     asm/jump_arm64_aapcs_elf_gas.S
+   : <abi>sysv
+     <address-model>64
+     <architecture>arm
+     <binary-format>elf
+     <toolset>gcc
+   ;
+
+
 # ARM64/AAPCS/ELF
 alias asm_context_sources
    : [ make asm/make_arm64_aapcs_elf_gas.o : asm/make_arm64_aapcs_elf_gas.S : @gas64 ]

--- a/include/boost/context/detail/fcontext_arm.hpp
+++ b/include/boost/context/detail/fcontext_arm.hpp
@@ -37,7 +37,11 @@ struct stack_t
 
 struct fp_t
 {
+#ifdef __aarch64__
+    boost::uint64_t     fc_freg[8];
+#else
     boost::uint32_t     fc_freg[16];
+#endif
 
     fp_t() :
         fc_freg()
@@ -46,6 +50,17 @@ struct fp_t
 
 struct fcontext_t
 {
+#ifdef __aarch64__
+    boost::uint64_t	fc_greg[13];
+    boost::uint64_t	align;
+    stack_t		fc_stack;
+    fp_t		fc_fp;
+    fcontext_t() :
+	 fc_greg(),
+	 fc_stack(),
+	 fc_fp()
+	 {}
+#else
     boost::uint32_t     fc_greg[11];
     stack_t             fc_stack;
     fp_t                fc_fp;
@@ -55,6 +70,7 @@ struct fcontext_t
         fc_stack(),
         fc_fp()
     {}
+#endif
 };
 
 }


### PR DESCRIPTION
Request review of changes required for boost::context support on aarch64.