### PR TITLE
have jump,make_fcontext show up as importable

### DIFF
--- a/src/asm/jump_ppc32_sysv_xcoff_gas.S
+++ b/src/asm/jump_ppc32_sysv_xcoff_gas.S
@@ -1,5 +1,9 @@
 .globl .jump_fcontext
+.globl  jump_fcontext[DS]
 .align 2 
+.csect	jump_fcontext[DS]
+jump_fcontext:
+  .long	.jump_fcontext
 .jump_fcontext:
     # reserve space on stack
     subi 1, 1, 240

--- a/src/asm/make_ppc32_sysv_xcoff_gas.S
+++ b/src/asm/make_ppc32_sysv_xcoff_gas.S
@@ -1,6 +1,9 @@
 	.globl	make_fcontext[DS]
 	.globl .make_fcontext[PR]
 	.align 2 
+	.csect  make_fcontext[DS]
+make_fcontext:
+	.long .make_fcontext[PR]
 	.csect .make_fcontext[PR], 3
 #.make_fcontext:
     # save return address into R6


### PR DESCRIPTION
On AIX, building with aix-soname=svr4, nm is used to list public symbols
in object files. This fixes the assembly to have make_fcontext and
jump_fcontext show up as public symbols.

The problem actually shows up when linking the coroutine library against the context library when built with aix-soname=svr4. 
However, except for this patch allowing to compile and link even coroutine, I'm unsure if the assembly is correct from all aspects, like alignment, TOC, and whether it works.