### PR TITLE
Do not export symbols for static build on PE builds.

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -28,6 +28,8 @@ project boost/context
       <toolset>clang,<segmented-stacks>on:<cxxflags>-fsplit-stack
       <toolset>clang,<segmented-stacks>on:<cxxflags>-DBOOST_USE_SEGMENTED_STACKS
       <toolset>clang,<segmented-stacks>on:<linkflags>"-static-libgcc"
+      <toolset>msvc,<link>shared:<define>BOOST_CONTEXT_EXPORT=EXPORT
+      <toolset>msvc,<link>static:<define>BOOST_CONTEXT_EXPORT=
       <link>shared:<define>BOOST_CONTEXT_DYN_LINK=1
       <define>BOOST_CONTEXT_SOURCE
       <threading>multi

--- a/src/asm/jump_i386_ms_pe_masm.asm
+++ b/src/asm/jump_i386_ms_pe_masm.asm
@@ -24,7 +24,7 @@
 .model flat, c
 .code
 
-jump_fcontext PROC EXPORT
+jump_fcontext PROC BOOST_CONTEXT_EXPORT
     ; fourth arg of jump_fcontext() == flag indicating preserving FPU
     mov  ecx, [esp+010h]
 

--- a/src/asm/jump_x86_64_ms_pe_masm.asm
+++ b/src/asm/jump_x86_64_ms_pe_masm.asm
@@ -77,7 +77,7 @@
 
 .code
 
-jump_fcontext PROC EXPORT FRAME
+jump_fcontext PROC BOOST_CONTEXT_EXPORT FRAME
     .endprolog
 
     push  rbp  ; save RBP

--- a/src/asm/make_i386_ms_pe_masm.asm
+++ b/src/asm/make_i386_ms_pe_masm.asm
@@ -26,7 +26,7 @@
 _exit PROTO, value:SDWORD
 .code
 
-make_fcontext PROC EXPORT
+make_fcontext PROC BOOST_CONTEXT_EXPORT
     ; first arg of make_fcontext() == top of context-stack
     mov  eax, [esp+04h]
 

--- a/src/asm/make_x86_64_ms_pe_masm.asm
+++ b/src/asm/make_x86_64_ms_pe_masm.asm
@@ -80,7 +80,7 @@ EXTERN  _exit:PROC
 .code
 
 ; generate function table entry in .pdata and unwind information in
-make_fcontext PROC EXPORT FRAME
+make_fcontext PROC BOOST_CONTEXT_EXPORT FRAME
     ; .xdata for a function's structured exception handling unwind behavior
     .endprolog
 


### PR DESCRIPTION
Symbols incorrectly marked for export on static libraries exported on final executable. This change make symbols not to be marked as export on static builds.