### PR TITLE
Fix several typos I spotted while reading the documentation

### DIFF
--- a/doc/context.xml
+++ b/doc/context.xml
@@ -1986,7 +1986,7 @@
         <ulink url="http://msdn.microsoft.com/en-us/library/4ks26t93.aspx">MSDN article
         'Inline Assembler'</ulink>
       </para>
-      </footnote>. Inlined assembler generates code bloating which his not welcome
+      </footnote>. Inlined assembler generates code bloating which is not welcome
       on embedded systems.
     </para>
     <bridgehead renderas="sect3" id="context.rationale.h1">

--- a/doc/context.xml
+++ b/doc/context.xml
@@ -284,7 +284,7 @@
     </important>
     <important>
       <para>
-        Do not jump from inside a catch block and than re-throw the exception in
+        Do not jump from inside a catch block and then re-throw the exception in
         another execution context.
       </para>
     </important>

--- a/doc/fcontext.qbk
+++ b/doc/fcontext.qbk
@@ -147,7 +147,7 @@ other context.
 If the __context_fn__ emits an exception, the behaviour is undefined.
 
 [important __context_fn__ should wrap the code in a try/catch block.]
-[important Do not jump from inside a catch block and than re-throw the
+[important Do not jump from inside a catch block and then re-throw the
 exception in another execution context.]
 
 

--- a/doc/html/context/context.html
+++ b/doc/html/context/context.html
@@ -237,7 +237,7 @@
 <th align="left">Important</th>
 </tr>
 <tr><td align="left" valign="top"><p>
-        Do not jump from inside a catch block and than re-throw the exception in
+        Do not jump from inside a catch block and then re-throw the exception in
         another execution context.
       </p></td></tr>
 </table></div>

--- a/doc/html/context/econtext/rationale.html
+++ b/doc/html/context/econtext/rationale.html
@@ -39,7 +39,7 @@
       </h5>
 <p>
         Some newer compiler (for instance MSVC 10 for x86_64 and itanium) do not
-        support inline assembler. <sup>[<a name="context.econtext.rationale.f0" href="#ftn.context.econtext.rationale.f0" class="footnote">1</a>]</sup>. Inlined assembler generates code bloating which his not welcome
+        support inline assembler. <sup>[<a name="context.econtext.rationale.f0" href="#ftn.context.econtext.rationale.f0" class="footnote">1</a>]</sup>. Inlined assembler generates code bloating which is not welcome
         on embedded systems.
       </p>
 <h5>

--- a/doc/html/context/rationale.html
+++ b/doc/html/context/rationale.html
@@ -38,7 +38,7 @@
     </h4>
 <p>
       Some newer compiler (for instance MSVC 10 for x86_64 and itanium) do not support
-      inline assembler. <sup>[<a name="context.rationale.f0" href="#ftn.context.rationale.f0" class="footnote">1</a>]</sup>. Inlined assembler generates code bloating which his not welcome
+      inline assembler. <sup>[<a name="context.rationale.f0" href="#ftn.context.rationale.f0" class="footnote">1</a>]</sup>. Inlined assembler generates code bloating which is not welcome
       on embedded systems.
     </p>
 <h4>

--- a/doc/rationale.qbk
+++ b/doc/rationale.qbk
@@ -13,7 +13,7 @@ Some newer compiler (for instance MSVC 10 for x86_64 and itanium) do not
 support inline assembler.
 [footnote [@http://msdn.microsoft.com/en-us/library/4ks26t93.aspx MSDN article
 'Inline Assembler']].
-Inlined assembler generates code bloating which his not welcome on embedded
+Inlined assembler generates code bloating which is not welcome on embedded
 systems.
 
 


### PR DESCRIPTION
Nothing major, just typos. I used `grep` and manual replacement to fix duplicate typos. These typos were spotted while reading the Boost.Coroutine doc; see this PR: https://github.com/boostorg/coroutine/pull/22

I don't think that I'll spot more typos soon. If I do, I'll behave like the Nagle's algorithm and will *not* open another pull request.