### PR TITLE
Fix signed pointer comparison.

### DIFF
--- a/include/boost/context/posix/protected_fixedsize_stack.hpp
+++ b/include/boost/context/posix/protected_fixedsize_stack.hpp
@@ -58,7 +58,7 @@ public:
                     static_cast< float >( size_) / traits_type::page_size() ) ) );
         BOOST_ASSERT_MSG( 2 <= pages, "at least two pages must fit into stack (one page is guard-page)");
         const std::size_t size__( pages * traits_type::page_size() );
-        BOOST_ASSERT( 0 < size_ && 0 < size__);
+        BOOST_ASSERT( 0 != size_ && 0 != size__);
         BOOST_ASSERT( size__ <= size_);
 
         // conform to POSIX.4 (POSIX.1b-1993, _POSIX_C_SOURCE=199309L)

--- a/include/boost/context/windows/protected_fixedsize_stack.hpp
+++ b/include/boost/context/windows/protected_fixedsize_stack.hpp
@@ -54,7 +54,7 @@ public:
                     static_cast< float >( size_) / traits_type::page_size() ) ) );
         BOOST_ASSERT_MSG( 2 <= pages, "at least two pages must fit into stack (one page is guard-page)");
         const std::size_t size__( pages * traits_type::page_size() );
-        BOOST_ASSERT( 0 < size_ && 0 < size__);
+        BOOST_ASSERT( 0 != size_ && 0 != size__);
         BOOST_ASSERT( size__ <= size_);
 
         void * vp = ::VirtualAlloc( 0, size__, MEM_COMMIT, PAGE_READWRITE);


### PR DESCRIPTION
I created this using find, grep, and sed. No manual editing, but lots of manual inspection. I'm pretty sure that this is correct, and I'm currently running all regression tests. I'll follow up on whether they are successful or not, but just wanted to provide grounds for discussion for https://github.com/boostorg/coroutine/issues/23 .