### PR TITLE
Support Xcode

### DIFF
--- a/include/boost/context/detail/config.hpp
+++ b/include/boost/context/detail/config.hpp
@@ -77,5 +77,10 @@
 #if _MSC_VER > 1800 // _MSC_VER == 1800 -> MS Visual Studio 2013
 # undef BOOST_CONTEXT_NO_EXECUTION_CONTEXT
 #endif
-
+// workaround: Xcode clang feature detection
+#if ! defined(__cpp_lib_integer_sequence) && __cpp_lib_integer_sequence < 201304
+#  if _LIBCPP_STD_VER > 11
+#     undef BOOST_CONTEXT_NO_EXECUTION_CONTEXT
+#  endif
+#endif
 #endif // BOOST_CONTEXT_DETAIL_CONFIG_H

--- a/include/boost/context/execution_context.ipp
+++ b/include/boost/context/execution_context.ipp
@@ -57,7 +57,7 @@ struct activation_record {
         flag_segmented_stack = 1 << 3
     };
 
-    thread_local static ptr_t   current_rec;
+    static ptr_t   current_rec;
 
     std::atomic< std::size_t >  use_count;
     fcontext_t                  fctx;

--- a/src/execution_context.cpp
+++ b/src/execution_context.cpp
@@ -11,6 +11,7 @@
 # include "boost/context/execution_context.hpp"
 
 # include <boost/config.hpp>
+# include <boost/thread/tss.hpp>
 
 # ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_PREFIX
@@ -20,11 +21,11 @@ namespace boost {
 namespace context {
 
 static detail::activation_record * main_rec() {
-    thread_local static detail::activation_record rec;
-    return & rec;
+    static boost::thread_specific_ptr<detail::activation_record> rec;
+    if (!rec.get()) rec.reset(new detail::activation_record);
+    return rec.get();
 }
 
-thread_local
 detail::activation_record::ptr_t
 detail::activation_record::current_rec = main_rec();
 


### PR DESCRIPTION
boost.context is not compatible with Xcode versions greater than 6.1 (as far as my google skills lead me to believe). A few things are required to work it out. I don't expect this pull request to be excepted as is, but wanted to provide something that builds as an example of what will need to be done.

#### config.hpp
I've added an additional workaround for detecting integer sequence w/ Xcode versions using clang 3.4 and up. if `_LIBCPP_STD_VER > 11` is pulled from the `<utility>` and is defined in this case.

#### execution_context.ipp
Apple decided to block support for thread local storage for whatever reason, and it won't compile as is. Unfortunately I know nothing about thread local storage, and found this hack from a pull request that was submitted to Textmate. This change brings in a dependency on boost_thread. Pretty sure this change is just as good as handing off static memory, since you would need to pass around the local storage wrapper to get it cleaned up properly.

*Compiling, building, running on Xcode 7.*