### PR TITLE
Fix {make,jump}_fcontext visibility with mingw

### DIFF
--- a/src/asm/jump_i386_ms_pe_gas.asm
+++ b/src/asm/jump_i386_ms_pe_gas.asm
@@ -138,3 +138,6 @@ _jump_fcontext:
 
     /* indirect jump to context */
     jmp  *%edx
+
+.section .drectve
+.ascii " -export:\"jump_fcontext\""

--- a/src/asm/jump_x86_64_ms_pe_gas.asm
+++ b/src/asm/jump_x86_64_ms_pe_gas.asm
@@ -223,3 +223,6 @@ jump_fcontext:
     /* indirect jump to context */
     jmp  *%r10
 .seh_endproc
+
+.section .drectve
+.ascii " -export:\"jump_fcontext\""

--- a/src/asm/make_i386_ms_pe_gas.asm
+++ b/src/asm/make_i386_ms_pe_gas.asm
@@ -122,3 +122,6 @@ finish:
     hlt
 
 .def	__exit;	.scl	2;	.type	32;	.endef  /* standard C library function */
+
+.section .drectve
+.ascii " -export:\"make_fcontext\""

--- a/src/asm/make_x86_64_ms_pe_gas.asm
+++ b/src/asm/make_x86_64_ms_pe_gas.asm
@@ -149,3 +149,6 @@ finish:
 .seh_endproc
 
 .def	_exit;	.scl	2;	.type	32;	.endef  /* standard C library function */
+
+.section .drectve
+.ascii " -export:\"make_fcontext\""


### PR DESCRIPTION
fixes #16, the first part of the fedora patch to force platform detection is not needed as it can be overriden from b2 arguments