### PR TITLE
Don't use Boost.Config build-time configure target.

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -895,8 +895,10 @@ alias asm_context_sources
 
 explicit asm_context_sources ;
 
+obj cxx11_hdr_mutex_check : ../build/cxx11_hdr_mutex.cpp ;
+explicit cxx11_hdr_mutex_check ;
 local cxx11_mutex = [ check-target-builds
-      ../../config/checks//cxx11_hdr_mutex "C++11 mutex"
+      cxx11_hdr_mutex_check "C++11 mutex"
     :
     : <library>/boost/thread//boost_thread
   ] ;

--- a/build/cxx11_hdr_mutex.cpp
+++ b/build/cxx11_hdr_mutex.cpp
@@ -1,0 +1,10 @@
+//          Copyright Kohei Takahashi 2016.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/config.hpp>
+
+#ifdef BOOST_NO_CXX11_HDR_MUTEX
+#error "C++11 <mutex> is not available."
+#endif


### PR DESCRIPTION
In some cases it doesn't respect config macros.

I believe this PR will fix build problem reported on devel ML but I can't test because I have no Mac (or similar environment).

Any comments and test results are welcome.
