### PR TITLE
Fix compilation in c++1z

### DIFF
--- a/include/boost/context/detail/apply.hpp
+++ b/include/boost/context/detail/apply.hpp
@@ -29,9 +29,9 @@ namespace detail {
 template< typename Fn, typename Tpl, std::size_t ... I >
 auto
 apply_impl( Fn && fn, Tpl && tpl, index_sequence< I ... >) 
-    -> decltype( invoke( std::forward< Fn >( fn), std::get< I >( std::forward< Tpl >( tpl) ) ... ) )
+    -> decltype( boost::context::detail::invoke( std::forward< Fn >( fn), std::get< I >( std::forward< Tpl >( tpl) ) ... ) )
 {
-    return invoke( std::forward< Fn >( fn), std::get< I >( std::forward< Tpl >( tpl) ) ... );
+    return boost::context::detail::invoke( std::forward< Fn >( fn), std::get< I >( std::forward< Tpl >( tpl) ) ... );
 }
 
 template< typename Fn, typename Tpl >


### PR DESCRIPTION
invoke() could resolve to both boost::context::detail::invoke and std::invoke
because of ADL, which would result in an ambiguous call error

This patch was tested on debian unstable, with gcc 6.2 and clang 3.9. Also, I didn't test the patch in this repository but directly on boost 1.61, but it should be safe enough.