### PR TITLE
Deliberate-failure tests shouldn't be optimized

### DIFF
--- a/test/test_callcc.cpp
+++ b/test/test_callcc.cpp
@@ -107,6 +107,8 @@ struct my_exception : public std::runtime_error {
 };
 
 #ifdef BOOST_MSVC
+// Optimizations can remove the integer-divide-by-zero here.
+#pragma optimize("", off)
 void seh( bool & catched) {
     __try {
         int i = 1;
@@ -115,6 +117,7 @@ void seh( bool & catched) {
         catched = true;
     }
 }
+#pragma optimize("", on)
 #endif
 
 ctx::continuation fn1( ctx::continuation && c) {

--- a/test/test_execution_context_v2.impl
+++ b/test/test_execution_context_v2.impl
@@ -105,6 +105,8 @@ struct my_exception : public std::runtime_error {
 };
 
 #ifdef BOOST_MSVC
+// Optimizations can remove the integer-divide-by-zero here.
+#pragma optimize("", off)
 void seh( bool & catched) {
     __try {
         int i = 1;
@@ -113,6 +115,7 @@ void seh( bool & catched) {
         catched = true;
     }
 }
+#pragma optimize("", on)
 #endif
 
 ctx::execution_context< void > fn1( int i, ctx::execution_context< void > && ctx) {


### PR DESCRIPTION
A few tests designed to deliberately fail appeal to UB (undefined
behavior), but as the MSVC optimizer improves we will take advantage of
that to remove UB statements. In order for deliberate failures to occur,
the tests must have the optimizer turned off.