### PR TITLE
added missing docs for `BOOST_USE_VALGRIND`

### DIFF
--- a/doc/stack.qbk
+++ b/doc/stack.qbk
@@ -345,7 +345,9 @@ structures.
 
 Running programs that switch stacks under valgrind causes problems.
 Property (b2 command-line) `valgrind=on` let valgrind treat the memory regions
-as stack space which suppresses the errors.
+as stack space which suppresses the errors. Users must define `BOOST_USE_VALGRIND`
+before including any Boost.Context headers when linking against Boost binaries
+compiled with `valgrind=on`.
 
 [endsect]
 


### PR DESCRIPTION
Silent ODR violations are very unpleasant.