### PR TITLE
Fix assembly for fcontext on ppc64/sysv/elf

### DIFF
--- a/src/asm/jump_ppc64_sysv_elf_gas.S
+++ b/src/asm/jump_ppc64_sysv_elf_gas.S
@@ -115,7 +115,7 @@ jump_fcontext:
     std  %r25, 96(%r1)  # save R25
     std  %r26, 104(%r1)  # save R26
     std  %r27, 112(%r1)  # save R27
-    std  %r29, 120(%r1)  # save R28
+    std  %r28, 120(%r1)  # save R28
     std  %r29, 128(%r1)  # save R29
     std  %r30, 136(%r1)  # save R30
     std  %r31, 144(%r1)  # save R31
@@ -174,9 +174,21 @@ jump_fcontext:
     # adjust stack
     addi  %r1, %r1, 184
 
+    # zero in r3 indicates first jump to context-function
+    cmpdi %r3, 0
+    beq use_entry_arg
+
     # return transfer_t
     std  %r6, 0(%r3)
     std  %r5, 8(%r3)
+
+    # jump to context
+    bctr
+
+use_entry_arg:
+    # copy transfer_t into transfer_fn arg registers
+    mr  %r3, %r6
+    mr  %r4, %r5
 
     # jump to context
     bctr

--- a/src/asm/make_ppc64_sysv_elf_gas.S
+++ b/src/asm/make_ppc64_sysv_elf_gas.S
@@ -124,10 +124,8 @@ make_fcontext:
     li   %r0, 0
     std  %r0, 184(%r3)
 
-    # compute address of returned transfer_t
-    addi %r0, %r3, 232
-    mr   %r4, %r0
-    std  %r4, 152(%r3)
+    # zero in r3 indicates first jump to context-function
+    std  %r0, 152(%r3)
 
     # load LR
     mflr  %r0

--- a/src/asm/ontop_ppc64_sysv_elf_gas.S
+++ b/src/asm/ontop_ppc64_sysv_elf_gas.S
@@ -115,7 +115,7 @@ ontop_fcontext:
     std  %r25, 96(%r1)  # save R25
     std  %r26, 104(%r1)  # save R26
     std  %r27, 112(%r1)  # save R27
-    std  %r29, 120(%r1)  # save R28
+    std  %r28, 120(%r1)  # save R28
     std  %r29, 128(%r1)  # save R29
     std  %r30, 136(%r1)  # save R30
     std  %r31, 144(%r1)  # save R31
@@ -136,9 +136,6 @@ ontop_fcontext:
     # restore RSP (pointing to context-data) from R4
     mr  %r1, %r4
 
-#if _CALL_ELF != 2
-    ld  %r2,  0(%r1)  # restore TOC
-#endif
     ld  %r14, 8(%r1)  # restore R14
     ld  %r15, 16(%r1)  # restore R15
     ld  %r16, 24(%r1)  # restore R16
@@ -157,28 +154,65 @@ ontop_fcontext:
     ld  %r29, 128(%r1)  # restore R29
     ld  %r30, 136(%r1)  # restore R30
     ld  %r31, 144(%r1)  # restore R31
-    ld  %r4,  152(%r1)  # restore hidden
+    ld  %r3,  152(%r1)  # restore hidden
 
     # restore CR
     ld  %r0, 160(%r1)
     mtcr  %r0
+
+    # copy transfer_t into ontop_fn arg registers
+    mr  %r4, %r7
+    # arg pointer already in %r5
+
+#if _CALL_ELF == 2
+    # restore CTR
+    mtctr  %r6
+#else
+    # restore CTR
+    ld   %r7, 0(%r6)
+    mtctr  %r7
+    # restore TOC
+    ld   %r2, 8(%r6)
+#endif
+
+    # zero in r3 indicates first jump to context-function
+    cmpdi  %r3, 0
+    beq  use_entry_arg
+
+    # hidden arg already in %r3
+
+return_to_ctx:
     # restore LR
     ld  %r0, 168(%r1)
     mtlr  %r0
-    # ignore PC
 
     # adjust stack
     addi  %r1, %r1, 184
 
-    # return transfer_t
-    std  %r7, 0(%r4)
-    std  %r5, 8(%r4)
-
-    # restore CTR
-    mtctr  %r6
-
     # jump to context
     bctr
+
+use_entry_arg:
+    # compute return-value struct address
+    # (passed has hidden arg to ontop_fn)
+    addi  %r3, %r1, 8
+
+    # jump to context and update LR
+    bctrl
+
+    # restore CTR
+    ld   %r7, 176(%r1)
+    mtctr  %r7
+#if _CALL_ELF != 2
+    # restore TOC
+    ld   %r2, 0(%r1)
+#endif
+
+    # copy returned transfer_t into entry_fn arg registers
+    ld  %r3, 8(%r1)
+    ld  %r4, 16(%r1)
+
+    b  return_to_ctx
 #if _CALL_ELF == 2
 	.size ontop_fcontext, .-ontop_fcontext
 #else

--- a/test/test_fcontext.cpp
+++ b/test/test_fcontext.cpp
@@ -9,6 +9,7 @@
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <cstdio>
 
 #include <boost/array.hpp>
 #include <boost/assert.hpp>


### PR DESCRIPTION
Fixes bugs in the `fcontext` assembly functions for the ppc64/sysv/elf platform.

See issue #50 for more details.

This patch was tested against the latest `develop` commit (a429ff6301) using GCC 5.4 on a POWER7 machine running RHEL 6.6. However, I am not at all familiar with the Boost built/test system, so I am not entirely confident that I ran the unit tests correctly. I ran the following command from the Boost project root directory:

    ./b2 cxxflags="-std=c++11" --build-dir="/tmp/nick/boost/build" --with-context libs/context/test

The tests ran and failed on the first test without the patch, and then several tests ran and all passed after applying the patch. I think that means the patch works correctly (as far as the functionality covered by those tests goes anyway). Note that since my platform only uses ELFv1, I was not able to verify the ELFv2-specific code.