### PR TITLE
Fix register usage for ppc64/sysv/elfv2

### DIFF
--- a/src/asm/jump_ppc64_sysv_elf_gas.S
+++ b/src/asm/jump_ppc64_sysv_elf_gas.S
@@ -119,7 +119,9 @@ jump_fcontext:
     std  %r29, 128(%r1)  # save R29
     std  %r30, 136(%r1)  # save R30
     std  %r31, 144(%r1)  # save R31
+#if _CALL_ELF != 2
     std  %r3,  152(%r1)  # save hidden
+#endif
 
     # save CR
     mfcr  %r0
@@ -133,10 +135,13 @@ jump_fcontext:
     # store RSP (pointing to context-data) in R6
     mr  %r6, %r1
 
+#if _CALL_ELF == 2
+    # restore RSP (pointing to context-data) from R3
+    mr  %r1, %r3
+#else
     # restore RSP (pointing to context-data) from R4
     mr  %r1, %r4
 
-#if _CALL_ELF != 2
     ld  %r2,  0(%r1)  # restore TOC
 #endif
     ld  %r14, 8(%r1)  # restore R14
@@ -157,7 +162,9 @@ jump_fcontext:
     ld  %r29, 128(%r1)  # restore R29
     ld  %r30, 136(%r1)  # restore R30
     ld  %r31, 144(%r1)  # restore R31
+#if _CALL_ELF != 2
     ld  %r3,  152(%r1)  # restore hidden
+#endif
 
     # restore CR
     ld  %r0, 160(%r1)
@@ -174,6 +181,15 @@ jump_fcontext:
     # adjust stack
     addi  %r1, %r1, 184
 
+#if _CALL_ELF == 2
+    # copy transfer_t into transfer_fn arg registers
+    mr  %r3, %r6
+    # arg pointer already in %r4
+
+    # jump to context
+    bctr
+	.size jump_fcontext, .-jump_fcontext
+#else
     # zero in r3 indicates first jump to context-function
     cmpdi %r3, 0
     beq use_entry_arg
@@ -192,9 +208,6 @@ use_entry_arg:
 
     # jump to context
     bctr
-#if _CALL_ELF == 2
-	.size jump_fcontext, .-jump_fcontext
-#else
 # ifdef _CALL_LINUX
 	.size .jump_fcontext, .-.L.jump_fcontext
 # else

--- a/src/asm/make_ppc64_sysv_elf_gas.S
+++ b/src/asm/make_ppc64_sysv_elf_gas.S
@@ -124,8 +124,10 @@ make_fcontext:
     li   %r0, 0
     std  %r0, 184(%r3)
 
+#if _CALL_ELF != 2
     # zero in r3 indicates first jump to context-function
     std  %r0, 152(%r3)
+#endif
 
     # load LR
     mflr  %r0

--- a/src/asm/ontop_ppc64_sysv_elf_gas.S
+++ b/src/asm/ontop_ppc64_sysv_elf_gas.S
@@ -119,7 +119,9 @@ ontop_fcontext:
     std  %r29, 128(%r1)  # save R29
     std  %r30, 136(%r1)  # save R30
     std  %r31, 144(%r1)  # save R31
+#if _CALL_ELF != 2
     std  %r3,  152(%r1)  # save hidden
+#endif
 
     # save CR
     mfcr  %r0
@@ -133,8 +135,13 @@ ontop_fcontext:
     # store RSP (pointing to context-data) in R7
     mr  %r7, %r1
 
+#if _CALL_ELF == 2
+    # restore RSP (pointing to context-data) from R3
+    mr  %r1, %r3
+#else
     # restore RSP (pointing to context-data) from R4
     mr  %r1, %r4
+#endif
 
     ld  %r14, 8(%r1)  # restore R14
     ld  %r15, 16(%r1)  # restore R15
@@ -154,32 +161,37 @@ ontop_fcontext:
     ld  %r29, 128(%r1)  # restore R29
     ld  %r30, 136(%r1)  # restore R30
     ld  %r31, 144(%r1)  # restore R31
+#if _CALL_ELF != 2
     ld  %r3,  152(%r1)  # restore hidden
+#endif
 
     # restore CR
     ld  %r0, 160(%r1)
     mtcr  %r0
 
+#if _CALL_ELF == 2
+    # restore CTR
+    mtctr  %r5
+
+    # copy transfer_t into ontop_fn arg registers
+    mr  %r3, %r7
+    # arg pointer already in %r4
+#else
     # copy transfer_t into ontop_fn arg registers
     mr  %r4, %r7
     # arg pointer already in %r5
+    # hidden arg already in %r3
 
-#if _CALL_ELF == 2
-    # restore CTR
-    mtctr  %r6
-#else
     # restore CTR
     ld   %r7, 0(%r6)
     mtctr  %r7
     # restore TOC
     ld   %r2, 8(%r6)
-#endif
 
     # zero in r3 indicates first jump to context-function
     cmpdi  %r3, 0
     beq  use_entry_arg
-
-    # hidden arg already in %r3
+#endif
 
 return_to_ctx:
     # restore LR
@@ -192,6 +204,9 @@ return_to_ctx:
     # jump to context
     bctr
 
+#if _CALL_ELF == 2
+	.size ontop_fcontext, .-ontop_fcontext
+#else
 use_entry_arg:
     # compute return-value struct address
     # (passed has hidden arg to ontop_fn)
@@ -213,9 +228,6 @@ use_entry_arg:
     ld  %r4, 16(%r1)
 
     b  return_to_ctx
-#if _CALL_ELF == 2
-	.size ontop_fcontext, .-ontop_fcontext
-#else
 # ifdef _CALL_LINUX
 	.size .ontop_fcontext, .-.L.ontop_fcontext
 # else


### PR DESCRIPTION
I was able to set up some PowerPC virtual machines using QEMU, and I tested the previous patch on ppc (32-bit), ppc64 big-endian (ELFv1), and ppc64 little-endian (ELFv2). The previous patch didn't work with ELFv2 (significant ABI differences from ELFv1). This version was tested and passes the unit tests on all three of the virtual machines mentioned above, although I was only able to run the fcontext test on the 32-bit ppc target since I was using an older version of GCC.