### PR TITLE
Fix compilation with gcc 4.9.

### DIFF
--- a/include/boost/context/continuation.hpp
+++ b/include/boost/context/continuation.hpp
@@ -270,6 +270,31 @@ detail::transfer_t context_ontop_void( detail::transfer_t t) {
 #endif
 }
 
+class continuation;
+
+template<
+    typename StackAlloc,
+    typename Fn,
+    typename ... Arg,
+    typename = detail::disable_overload< preallocated, StackAlloc >
+#if defined(BOOST_USE_SEGMENTED_STACKS)
+    , typename = detail::disable_overload< segmented_stack, StackAlloc >
+#endif
+>
+continuation
+callcc( std::allocator_arg_t, StackAlloc salloc, Fn && fn, Arg ... arg);
+
+template<
+    typename StackAlloc,
+    typename Fn,
+    typename ... Arg
+#if defined(BOOST_USE_SEGMENTED_STACKS)
+    , typename = detail::disable_overload< segmented_stack, StackAlloc >
+#endif
+>
+continuation
+callcc( std::allocator_arg_t, preallocated palloc, StackAlloc salloc, Fn && fn, Arg ... arg);
+
 class continuation {
 private:
     template< typename Ctx, typename StackAlloc, typename Fn >
@@ -283,21 +308,28 @@ private:
     friend detail::transfer_t
     context_ontop_void( detail::transfer_t);
 
-    template< typename StackAlloc, typename Fn, typename ... Arg >
+    template<
+        typename StackAlloc,
+        typename Fn,
+        typename ... Arg,
+        typename
+#if defined(BOOST_USE_SEGMENTED_STACKS)
+        , typename
+#endif
+     >
     friend continuation
     callcc( std::allocator_arg_t, StackAlloc, Fn &&, Arg ...);
 
-    template< typename StackAlloc, typename Fn, typename ... Arg >
+    template<
+        typename StackAlloc,
+        typename Fn,
+        typename ... Arg
+#if defined(BOOST_USE_SEGMENTED_STACKS)
+        , typename
+#endif
+     >
     friend continuation
     callcc( std::allocator_arg_t, preallocated, StackAlloc, Fn &&, Arg ...);
-
-    template< typename StackAlloc, typename Fn >
-    friend continuation
-    callcc( std::allocator_arg_t, StackAlloc, Fn &&);
-
-    template< typename StackAlloc, typename Fn >
-    friend continuation
-    callcc( std::allocator_arg_t, preallocated, StackAlloc, Fn &&);
 
     detail::transfer_t  t_{ nullptr, nullptr };
 
@@ -447,11 +479,11 @@ public:
     }
 };
 
-// Arg
 template<
     typename Fn,
     typename ... Arg,
-    typename = detail::disable_overload< continuation, Fn >
+    typename = detail::disable_overload< continuation, Fn >,
+    typename = detail::disable_overload< std::allocator_arg_t, Fn >
 >
 continuation
 callcc( Fn && fn, Arg ... arg) {
@@ -463,7 +495,11 @@ callcc( Fn && fn, Arg ... arg) {
 template<
     typename StackAlloc,
     typename Fn,
-    typename ... Arg
+    typename ... Arg,
+    typename // = detail::disable_overload< preallocated, StackAlloc >
+#if defined(BOOST_USE_SEGMENTED_STACKS)
+    , typename // = detail::disable_overload< segmented_stack, StackAlloc >
+#endif
 >
 continuation
 callcc( std::allocator_arg_t, StackAlloc salloc, Fn && fn, Arg ... arg) {
@@ -478,6 +514,9 @@ template<
     typename StackAlloc,
     typename Fn,
     typename ... Arg
+#if defined(BOOST_USE_SEGMENTED_STACKS)
+    , typename // = detail::disable_overload< segmented_stack, StackAlloc >
+#endif
 >
 continuation
 callcc( std::allocator_arg_t, preallocated palloc, StackAlloc salloc, Fn && fn, Arg ... arg) {
@@ -486,36 +525,6 @@ callcc( std::allocator_arg_t, preallocated palloc, StackAlloc salloc, Fn && fn, 
                         detail::context_create< Record >(
                                palloc, salloc, std::forward< Fn >( fn) ) }.resume(
                    std::forward< Arg >( arg) ... );
-}
-
-// void
-template<
-    typename Fn,
-    typename = detail::disable_overload< continuation, Fn >
->
-continuation
-callcc( Fn && fn) {
-    return callcc(
-            std::allocator_arg, fixedsize_stack(),
-            std::forward< Fn >( fn) );
-}
-
-template< typename StackAlloc, typename Fn >
-continuation
-callcc( std::allocator_arg_t, StackAlloc salloc, Fn && fn) {
-    using Record = detail::record< continuation, StackAlloc, Fn >;
-    return continuation{
-                detail::context_create< Record >(
-                        salloc, std::forward< Fn >( fn) ) }.resume();
-}
-
-template< typename StackAlloc, typename Fn >
-continuation
-callcc( std::allocator_arg_t, preallocated palloc, StackAlloc salloc, Fn && fn) {
-    using Record = detail::record< continuation, StackAlloc, Fn >;
-    return continuation{
-                detail::context_create< Record >(
-                        palloc, salloc, std::forward< Fn >( fn) ) }.resume();
 }
 
 #if defined(BOOST_USE_SEGMENTED_STACKS)


### PR DESCRIPTION
The compiler apparently has problems with template ordering, so:

- Remove callcc overloads that have no arguments for the function. These
  overloads are ambiguous with the overloads taking variadic args. The
  no-args case is covered by the variadic iverloads anyway.

- Enforce overload resolution with SFINAE. Disable instantiating templated
  overloads with arguments for which non-templated version of callcc is
  provided.

- Update friend declarations of callcc in continuation to match the callcc
  function signatures, including the template arguments. Otherwise, friend
  declarations declare additional overloads of callcc which ambiguate
  overload resolution. To do this, the callcc functions have to be
  forward-declared before the continuation class (default template arguments
  cannot be specified in friend declarations).

As a result, the compilation succeeds with gcc 4.9.4, but test_callcc.cpp still fails. I'm not familiar with the library to debug the test (my main concern now is compilation).

Tests passed with gcc 6.3.
