### PR TITLE
Fix callcc functionality for g++-4.9

### DIFF
--- a/include/boost/context/continuation.hpp
+++ b/include/boost/context/continuation.hpp
@@ -56,7 +56,7 @@ namespace boost {
 namespace context {
 namespace detail {
 
-template< int N >
+template<typename U>
 struct helper {
     template< typename T >
     static T convert( T && t) noexcept {
@@ -64,8 +64,8 @@ struct helper {
     }
 };
 
-template<>
-struct helper< 1 > {
+template<typename U>
+struct helper< std::tuple<U> > {
     template< typename T >
     static std::tuple< T > convert( T && t) noexcept {
         return std::make_tuple( std::forward< T >( t) );
@@ -239,15 +239,16 @@ struct result_type< Arg > {
 
 }
 
-template< typename Ctx, typename Fn, typename ... Arg >
+template< typename Ctx, typename Fn, typename Arg >
 detail::transfer_t context_ontop( detail::transfer_t t) {
-    auto p = static_cast< std::tuple< Fn, std::tuple< Arg ... > > * >( t.data);
+    auto p = static_cast< Arg * >( t.data);
     BOOST_ASSERT( nullptr != p);
     typename std::decay< Fn >::type fn = std::forward< Fn >( std::get< 0 >( * p) );
     t.data = & std::get< 1 >( * p);
     Ctx c{ t };
     // execute function, pass continuation via reference
-    std::get< 1 >( * p) = detail::helper< sizeof ... (Arg) >::convert( fn( std::move( c) ) );
+    typedef typename std::decay<decltype(std::get<1>(*p))>::type H;
+    std::get< 1 >(* p) = detail::helper<H>::convert( fn( std::move( c) ) );
 #if defined(BOOST_NO_CXX14_STD_EXCHANGE)
     return { detail::exchange( c.t_.fctx, nullptr), & std::get< 1 >( * p) };
 #else
@@ -275,7 +276,7 @@ private:
     template< typename Ctx, typename StackAlloc, typename Fn >
     friend class detail::record;
 
-    template< typename Ctx, typename Fn, typename ... Arg >
+    template< typename Ctx, typename Fn, typename Arg >
     friend detail::transfer_t
     context_ontop( detail::transfer_t);
 
@@ -354,7 +355,7 @@ public:
     template< typename Fn, typename ... Arg >
     continuation resume_with( Fn && fn, Arg ... arg) {
         BOOST_ASSERT( nullptr != t_.fctx);
-        auto tpl = std::make_tuple( std::forward< Fn >( fn), std::forward< Arg >( arg) ... );
+        auto tpl = std::make_tuple( std::forward< Fn >( fn), std::make_tuple( std::forward< Arg >( arg) ... ));
         return detail::ontop_fcontext(
 #if defined(BOOST_NO_CXX14_STD_EXCHANGE)
                     detail::exchange( t_.fctx, nullptr),
@@ -362,7 +363,7 @@ public:
                     std::exchange( t_.fctx, nullptr),
 #endif
                     & tpl,
-                    context_ontop< continuation, Fn, Arg ... >);
+                    context_ontop< continuation, Fn, decltype(tpl) >);
     }
 
     continuation resume() {
@@ -451,7 +452,8 @@ public:
 template<
     typename Fn,
     typename ... Arg,
-    typename = detail::disable_overload< continuation, Fn >
+    typename = detail::disable_overload< continuation, Fn >,
+    typename = detail::disable_overload< std::allocator_arg_t, Fn >
 >
 continuation
 callcc( Fn && fn, Arg ... arg) {


### PR DESCRIPTION
Fixes the resolution issue discussed in #52 and #54 that caused compiler errors when using g++-4.9. Also fixes a bad cast that was causing bad values to be passed as arguments into continuations.