### PR TITLE
Fix i386/macho routines to correctly return transfer_t in EAX/EDX

### DIFF
--- a/src/asm/jump_i386_sysv_macho_gas.S
+++ b/src/asm/jump_i386_sysv_macho_gas.S
@@ -12,14 +12,14 @@
  *  ----------------------------------------------------------------------------------  *
  *  |   0x0   |   0x4   |   0x8   |   0xc   |   0x10   |   0x14  |   0x18  |   0x1c  |  *
  *  ----------------------------------------------------------------------------------  *
- *  | fc_mxcsr|fc_x87_cw|   EDI   |   ESI   |   EBX    |   EBP   |   EIP   |  hidden |  *
+ *  | fc_mxcsr|fc_x87_cw|   EDI   |   ESI   |   EBX    |   EBP   |   EIP   |    to   |  *
  *  ----------------------------------------------------------------------------------  *
  *  ----------------------------------------------------------------------------------  *
  *  |    8    |    9    |    10   |    11   |    12    |    13   |    14   |    15   |  *
  *  ----------------------------------------------------------------------------------  *
- *  |   0x20  |   0x24  |                                                            |  *
+ *  |   0x20  |                                                                      |  *
  *  ----------------------------------------------------------------------------------  *
- *  |    to   |   data  |                                                            |  *
+ *  |   data  |                                                                      |  *
  *  ----------------------------------------------------------------------------------  *
  *                                                                                      *
  ****************************************************************************************/
@@ -44,20 +44,17 @@ _jump_fcontext:
     movl  %esp, %ecx
 
     /* first arg of jump_fcontext() == fcontext to jump to */
-    movl  0x20(%esp), %eax
+    movl  0x1c(%esp), %eax
 
     /* second arg of jump_fcontext() == data to be transferred */
-    movl  0x24(%esp), %edx
+    movl  0x20(%esp), %edx
 
     /* restore ESP (pointing to context-data) from EAX */
     movl  %eax, %esp
 
-    /* address of returned transport_t */
-    movl 0x1c(%esp), %eax
     /* return parent fcontext_t */
-    movl  %ecx, (%eax)
-    /* return data */
-    movl %edx, 0x4(%eax)
+    movl  %ecx, %eax
+    /* returned data is stored in EDX */
 
     movl  0x18(%esp), %ecx  /* restore EIP */
 
@@ -71,7 +68,7 @@ _jump_fcontext:
     movl  0x10(%esp), %ebx  /* restore EBX */
     movl  0x14(%esp), %ebp  /* restore EBP */
 
-    leal  0x20(%esp), %esp  /* prepare stack */
+    leal  0x1c(%esp), %esp  /* prepare stack */
 
     /* jump to context */
     jmp *%ecx

--- a/src/asm/make_i386_sysv_macho_gas.S
+++ b/src/asm/make_i386_sysv_macho_gas.S
@@ -12,14 +12,14 @@
  *  ----------------------------------------------------------------------------------  *
  *  |   0x0   |   0x4   |   0x8   |   0xc   |   0x10   |   0x14  |   0x18  |   0x1c  |  *
  *  ----------------------------------------------------------------------------------  *
- *  | fc_mxcsr|fc_x87_cw|   EDI   |   ESI   |   EBX    |   EBP   |   EIP   |  hidden |  *
+ *  | fc_mxcsr|fc_x87_cw|   EDI   |   ESI   |   EBX    |   EBP   |   EIP   |    to   |  *
  *  ----------------------------------------------------------------------------------  *
  *  ----------------------------------------------------------------------------------  *
  *  |    8    |    9    |    10   |    11   |    12    |    13   |    14   |    15   |  *
  *  ----------------------------------------------------------------------------------  *
- *  |   0x20  |   0x24  |                                                            |  *
+ *  |   0x20  |                                                                      |  *
  *  ----------------------------------------------------------------------------------  *
- *  |    to   |   data  |                                                            |  *
+ *  |   data  |                                                                      |  *
  *  ----------------------------------------------------------------------------------  *
  *                                                                                      *
  ****************************************************************************************/
@@ -39,7 +39,7 @@ _make_fcontext:
     andl  $-16, %eax
 
     /* reserve space for context-data on context-stack */
-    leal  -0x28(%eax), %eax
+    leal  -0x2c(%eax), %eax
 
     /* third arg of make_fcontext() == address of context-function */
     /* stored in EBX */
@@ -50,11 +50,6 @@ _make_fcontext:
     stmxcsr (%eax)
     /* save x87 control-word */
     fnstcw  0x4(%eax)
-
-    /* return transport_t */
-    /* FCTX == EDI, DATA == ESI */
-    leal  0x8(%eax), %ecx
-    movl  %ecx, 0x1c(%eax)
 
     /* compute abs address of label trampoline */
     call  1f
@@ -80,8 +75,8 @@ _make_fcontext:
 
 trampoline:
     /* move transport_t for entering context-function */
-    movl  %edi, (%esp)
-    movl  %esi, 0x4(%esp)
+    movl  %eax, (%esp)
+    movl  %edx, 0x4(%esp)
     pushl %ebp
     /* jump to context-function */
     jmp *%ebx

--- a/src/asm/ontop_i386_sysv_macho_gas.S
+++ b/src/asm/ontop_i386_sysv_macho_gas.S
@@ -12,14 +12,14 @@
  *  ----------------------------------------------------------------------------------  *
  *  |   0x0   |   0x4   |   0x8   |   0xc   |   0x10   |   0x14  |   0x18  |   0x1c  |  *
  *  ----------------------------------------------------------------------------------  *
- *  | fc_mxcsr|fc_x87_cw|   EDI   |   ESI   |   EBX    |   EBP   |   EIP   |  hidden |  *
+ *  | fc_mxcsr|fc_x87_cw|   EDI   |   ESI   |   EBX    |   EBP   |   EIP   |    to   |  *
  *  ----------------------------------------------------------------------------------  *
  *  ----------------------------------------------------------------------------------  *
  *  |    8    |    9    |    10   |    11   |    12    |    13   |    14   |    15   |  *
  *  ----------------------------------------------------------------------------------  *
- *  |   0x20  |   0x24  |                                                            |  *
+ *  |   0x20  |                                                                      |  *
  *  ----------------------------------------------------------------------------------  *
- *  |    to   |   data  |                                                            |  *
+ *  |   data  |                                                                      |  *
  *  ----------------------------------------------------------------------------------  *
  *                                                                                      *
  ****************************************************************************************/
@@ -44,29 +44,26 @@ _ontop_fcontext:
     movl  %esp, %ecx
 
     /* first arg of ontop_fcontext() == fcontext to jump to */
-    movl  0x20(%esp), %eax
+    movl  0x1c(%esp), %eax
 
     /* pass parent fcontext_t */
-    movl  %ecx, 0x20(%eax)
+    movl  %ecx, 0x1c(%eax)
 
     /* second arg of ontop_fcontext() == data to be transferred */
-    movl  0x24(%esp), %ecx
+    movl  0x20(%esp), %ecx
 
     /* pass data */
-    movl %ecx, 0x24(%eax)
+    movl %ecx, 0x20(%eax)
 
     /* third arg of ontop_fcontext() == ontop-function */
-    movl  0x28(%esp), %ecx
+    movl  0x24(%esp), %ecx
 
     /* restore ESP (pointing to context-data) from EAX */
     movl  %eax, %esp
 
-    /* address of returned transport_t */
-    movl 0x1c(%esp), %eax
     /* return parent fcontext_t */
-    movl  %ecx, (%eax)
-    /* return data */
-    movl %edx, 0x4(%eax)
+    movl  %ecx, %eax
+    /* returned data is stored in EDX */
 
 #if !defined(BOOST_USE_TSX)
     ldmxcsr  (%esp)     /* restore MMX control- and status-word */


### PR DESCRIPTION
The OSX 32bit ABI differs from the System V ABI in that 8 byte structs
are returned in registers EAX/EDX instead of passing the address of the
struct on the stack. See: https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/LowLevelABI/130-IA-32_Function_Calling_Conventions/IA32.html

The current implementation for this platform crashes when compiled for
32bit OSX (e.g. when running a 32bit iOS simulator) due to not
satisfying the ABI.