### PR TITLE
use perfect forwarding for StackAlloc

### DIFF
--- a/include/boost/context/continuation_fcontext.hpp
+++ b/include/boost/context/continuation_fcontext.hpp
@@ -107,11 +107,11 @@ template< typename Ctx, typename StackAlloc, typename Fn >
 class record {
 private:
     stack_context                                       sctx_;
-    StackAlloc                                          salloc_;
+    typename std::decay< StackAlloc >::type             salloc_;
     typename std::decay< Fn >::type                     fn_;
 
     static void destroy( record * p) noexcept {
-        StackAlloc salloc = p->salloc_;
+        typename std::decay< StackAlloc >::type salloc = std::move( p->salloc_);
         stack_context sctx = p->sctx_;
         // deallocate record
         p->~record();
@@ -120,10 +120,10 @@ private:
     }
 
 public:
-    record( stack_context sctx, StackAlloc const& salloc,
+    record( stack_context sctx, StackAlloc && salloc,
             Fn && fn) noexcept :
         sctx_( sctx),
-        salloc_( salloc),
+        salloc_( std::forward< StackAlloc >( salloc)),
         fn_( std::forward< Fn >( fn) ) {
     }
 
@@ -151,7 +151,7 @@ public:
 };
 
 template< typename Record, typename StackAlloc, typename Fn >
-fcontext_t create_context1( StackAlloc salloc, Fn && fn) {
+fcontext_t create_context1( StackAlloc && salloc, Fn && fn) {
     auto sctx = salloc.allocate();
     // reserve space for control structure
 	void * storage = reinterpret_cast< void * >(
@@ -159,7 +159,7 @@ fcontext_t create_context1( StackAlloc salloc, Fn && fn) {
             & ~static_cast< uintptr_t >( 0xff) );
     // placment new for control structure on context stack
     Record * record = new ( storage) Record{
-            sctx, salloc, std::forward< Fn >( fn) };
+            sctx, std::forward< StackAlloc >( salloc), std::forward< Fn >( fn) };
     // 64byte gab between control structure and stack top
     // should be 16byte aligned
     void * stack_top = reinterpret_cast< void * >(
@@ -175,14 +175,14 @@ fcontext_t create_context1( StackAlloc salloc, Fn && fn) {
 }
 
 template< typename Record, typename StackAlloc, typename Fn >
-fcontext_t create_context2( preallocated palloc, StackAlloc salloc, Fn && fn) {
+fcontext_t create_context2( preallocated palloc, StackAlloc && salloc, Fn && fn) {
     // reserve space for control structure
     void * storage = reinterpret_cast< void * >(
             ( reinterpret_cast< uintptr_t >( palloc.sp) - static_cast< uintptr_t >( sizeof( Record) ) )
             & ~ static_cast< uintptr_t >( 0xff) );
     // placment new for control structure on context-stack
     Record * record = new ( storage) Record{
-            palloc.sctx, salloc, std::forward< Fn >( fn) };
+            palloc.sctx, std::forward< StackAlloc >( salloc), std::forward< Fn >( fn) };
     // 64byte gab between control structure and stack top
     void * stack_top = reinterpret_cast< void * >(
             reinterpret_cast< uintptr_t >( storage) - static_cast< uintptr_t >( 64) );
@@ -209,11 +209,11 @@ private:
 
     template< typename StackAlloc, typename Fn >
     friend continuation
-    callcc( std::allocator_arg_t, StackAlloc, Fn &&);
+    callcc( std::allocator_arg_t, StackAlloc &&, Fn &&);
 
     template< typename StackAlloc, typename Fn >
     friend continuation
-    callcc( std::allocator_arg_t, preallocated, StackAlloc, Fn &&);
+    callcc( std::allocator_arg_t, preallocated, StackAlloc &&, Fn &&);
 
     detail::fcontext_t  fctx_{ nullptr };
 
@@ -337,20 +337,20 @@ callcc( Fn && fn) {
 
 template< typename StackAlloc, typename Fn >
 continuation
-callcc( std::allocator_arg_t, StackAlloc salloc, Fn && fn) {
+callcc( std::allocator_arg_t, StackAlloc && salloc, Fn && fn) {
     using Record = detail::record< continuation, StackAlloc, Fn >;
     return continuation{
                 detail::create_context1< Record >(
-                        salloc, std::forward< Fn >( fn) ) }.resume();
+                        std::forward< StackAlloc >( salloc), std::forward< Fn >( fn) ) }.resume();
 }
 
 template< typename StackAlloc, typename Fn >
 continuation
-callcc( std::allocator_arg_t, preallocated palloc, StackAlloc salloc, Fn && fn) {
+callcc( std::allocator_arg_t, preallocated palloc, StackAlloc && salloc, Fn && fn) {
     using Record = detail::record< continuation, StackAlloc, Fn >;
     return continuation{
                 detail::create_context2< Record >(
-                        palloc, salloc, std::forward< Fn >( fn) ) }.resume();
+                        palloc, std::forward< StackAlloc >( salloc), std::forward< Fn >( fn) ) }.resume();
 }
 
 #if defined(BOOST_USE_SEGMENTED_STACKS)

--- a/include/boost/context/continuation_winfib.hpp
+++ b/include/boost/context/continuation_winfib.hpp
@@ -197,11 +197,11 @@ struct forced_unwind {
 template< typename Ctx, typename StackAlloc, typename Fn >
 class capture_record : public activation_record {
 private:
-    StackAlloc                                          salloc_;
+    typename std::decay< StackAlloc >::type             salloc_;
     typename std::decay< Fn >::type                     fn_;
 
     static void destroy( capture_record * p) noexcept {
-        StackAlloc salloc = p->salloc_;
+        typename std::decay< StackAlloc >::type salloc = std::move( p->salloc_);
         stack_context sctx = p->sctx;
         // deallocate activation record
         p->~capture_record();
@@ -210,9 +210,9 @@ private:
     }
 
 public:
-    capture_record( stack_context sctx, StackAlloc salloc, Fn && fn) noexcept :
+    capture_record( stack_context sctx, StackAlloc && salloc, Fn && fn) noexcept :
         activation_record( sctx),
-        salloc_( salloc),
+        salloc_( std::forward< StackAlloc >( salloc)),
         fn_( std::forward< Fn >( fn) ) {
     }
 
@@ -244,7 +244,7 @@ public:
 };
 
 template< typename Ctx, typename StackAlloc, typename Fn >
-static activation_record * create_context1( StackAlloc salloc, Fn && fn) {
+static activation_record * create_context1( StackAlloc && salloc, Fn && fn) {
     typedef capture_record< Ctx, StackAlloc, Fn >  capture_t;
 
     auto sctx = salloc.allocate();
@@ -255,14 +255,14 @@ static activation_record * create_context1( StackAlloc salloc, Fn && fn) {
             & ~ static_cast< uintptr_t >( 0xff) );
     // placment new for control structure on context stack
     capture_t * record = new ( storage) capture_t{
-            sctx, salloc, std::forward< Fn >( fn) };
+            sctx, std::forward< StackAlloc >( salloc), std::forward< Fn >( fn) };
     // create user-context
     record->fiber = ::CreateFiber( sctx.size, & detail::entry_func< capture_t >, record);
     return record;
 }
 
 template< typename Ctx, typename StackAlloc, typename Fn >
-static activation_record * create_context2( preallocated palloc, StackAlloc salloc, Fn && fn) {
+static activation_record * create_context2( preallocated palloc, StackAlloc && salloc, Fn && fn) {
     typedef capture_record< Ctx, StackAlloc, Fn >  capture_t; 
 
     BOOST_ASSERT( ( sizeof( capture_t) ) < palloc.size);
@@ -272,7 +272,7 @@ static activation_record * create_context2( preallocated palloc, StackAlloc sall
             & ~ static_cast< uintptr_t >( 0xff) );
     // placment new for control structure on context stack
     capture_t * record = new ( storage) capture_t{
-            palloc.sctx, salloc, std::forward< Fn >( fn) };
+            palloc.sctx, std::forward< StackAlloc >( salloc), std::forward< Fn >( fn) };
     // create user-context
     record->fiber = ::CreateFiber( palloc.sctx.size, & detail::entry_func< capture_t >, record);
     return record;
@@ -288,18 +288,18 @@ private:
     friend class detail::capture_record;
 
     template< typename Ctx, typename StackAlloc, typename Fn >
-    friend detail::activation_record * detail::create_context1( StackAlloc, Fn &&);
+    friend detail::activation_record * detail::create_context1( StackAlloc &&, Fn &&);
 
     template< typename Ctx, typename StackAlloc, typename Fn >
-    friend detail::activation_record * detail::create_context2( preallocated, StackAlloc, Fn &&);
+    friend detail::activation_record * detail::create_context2( preallocated, StackAlloc &&, Fn &&);
 
     template< typename StackAlloc, typename Fn >
     friend continuation
-    callcc( std::allocator_arg_t, StackAlloc, Fn &&);
+    callcc( std::allocator_arg_t, StackAlloc &&, Fn &&);
 
     template< typename StackAlloc, typename Fn >
     friend continuation
-    callcc( std::allocator_arg_t, preallocated, StackAlloc, Fn &&);
+    callcc( std::allocator_arg_t, preallocated, StackAlloc &&, Fn &&);
 
     detail::activation_record   *   ptr_{ nullptr };
 
@@ -430,18 +430,18 @@ callcc( Fn && fn) {
 
 template< typename StackAlloc, typename Fn >
 continuation
-callcc( std::allocator_arg_t, StackAlloc salloc, Fn && fn) {
+callcc( std::allocator_arg_t, StackAlloc && salloc, Fn && fn) {
     return continuation{
         detail::create_context1< continuation >(
-                salloc, std::forward< Fn >( fn) ) }.resume();
+                std::forward< StackAlloc >( salloc), std::forward< Fn >( fn) ) }.resume();
 }
 
 template< typename StackAlloc, typename Fn >
 continuation
-callcc( std::allocator_arg_t, preallocated palloc, StackAlloc salloc, Fn && fn) {
+callcc( std::allocator_arg_t, preallocated palloc, StackAlloc && salloc, Fn && fn) {
     return continuation{
         detail::create_context2< continuation >(
-                palloc, salloc, std::forward< Fn >( fn) ) }.resume();
+                palloc, std::forward< StackAlloc >( salloc), std::forward< Fn >( fn) ) }.resume();
 }
 
 inline

--- a/include/boost/context/execution_context_v1.hpp
+++ b/include/boost/context/execution_context_v1.hpp
@@ -170,13 +170,13 @@ transfer_t context_ontop( transfer_t t) {
 template< typename StackAlloc, typename Fn, typename ... Args >
 class capture_record : public activation_record {
 private:
-    StackAlloc                                          salloc_;
+    typename std::decay< StackAlloc >::type             salloc_;
     typename std::decay< Fn >::type                     fn_;
     std::tuple< typename std::decay< Args >::type ... > args_;
     activation_record                               *   caller_;
 
     static void destroy( capture_record * p) noexcept {
-        StackAlloc salloc = p->salloc_;
+        typename std::decay< StackAlloc >::type salloc = std::move( p->salloc_);
         stack_context sctx = p->sctx;
         // deallocate activation record
         p->~capture_record();
@@ -185,12 +185,12 @@ private:
     }
 
 public:
-    capture_record( stack_context sctx, StackAlloc const& salloc,
+    capture_record( stack_context sctx, StackAlloc && salloc,
                     fcontext_t fctx,
                     activation_record * caller,
                     Fn && fn, Args && ... args) noexcept :
         activation_record{ fctx, sctx },
-        salloc_{ salloc },
+        salloc_{ std::forward< StackAlloc >( salloc) },
         fn_( std::forward< Fn >( fn) ),
         args_( std::forward< Args >( args) ... ),
         caller_{ caller } {
@@ -233,7 +233,7 @@ private:
     ptr_t   ptr_;
 
     template< typename StackAlloc, typename Fn, typename ... Args >
-    static detail::activation_record * create_context( StackAlloc salloc,
+    static detail::activation_record * create_context( StackAlloc && salloc,
                                                        Fn && fn, Args && ... args) {
         typedef detail::capture_record<
             StackAlloc, Fn, Args ...
@@ -263,11 +263,11 @@ private:
         auto curr = execution_context::current().ptr_;
         // placment new for control structure on fast-context stack
         return ::new ( sp) capture_t{
-                sctx, salloc, fctx, curr.get(), std::forward< Fn >( fn), std::forward< Args >( args) ... };
+                sctx, std::forward< StackAlloc >( salloc), fctx, curr.get(), std::forward< Fn >( fn), std::forward< Args >( args) ... };
     }
 
     template< typename StackAlloc, typename Fn, typename ... Args >
-    static detail::activation_record * create_context( preallocated palloc, StackAlloc salloc,
+    static detail::activation_record * create_context( preallocated palloc, StackAlloc && salloc,
                                                        Fn && fn, Args && ... args) {
         typedef detail::capture_record<
             StackAlloc, Fn, Args ...
@@ -296,7 +296,7 @@ private:
         auto curr = execution_context::current().ptr_;
         // placment new for control structure on fast-context stack
         return ::new ( sp) capture_t{
-                palloc.sctx, salloc, fctx, curr.get(), std::forward< Fn >( fn), std::forward< Args >( args) ... };
+                palloc.sctx, std::forward< StackAlloc >( salloc), fctx, curr.get(), std::forward< Fn >( fn), std::forward< Args >( args) ... };
     }
 
     execution_context() noexcept :
@@ -333,7 +333,7 @@ public:
         // non-type template parameter pack via std::index_sequence_for<>
         // preserves the number of arguments
         // used to extract the function arguments from std::tuple<>
-        ptr_{ create_context( salloc,
+        ptr_{ create_context( std::forward< StackAlloc >( salloc),
                               std::forward< Fn >( fn),
                               std::forward< Args >( args) ...) } {
         ptr_->resume( ptr_.get() );
@@ -348,7 +348,7 @@ public:
         // non-type template parameter pack via std::index_sequence_for<>
         // preserves the number of arguments
         // used to extract the function arguments from std::tuple<>
-        ptr_{ create_context( palloc, salloc,
+        ptr_{ create_context( palloc, std::forward< StackAlloc >( salloc),
                               std::forward< Fn >( fn),
                               std::forward< Args >( args) ...) } {
         ptr_->resume( ptr_.get() );
@@ -374,13 +374,13 @@ public:
               typename Fn,
               typename ... Args
     >
-    execution_context( std::allocator_arg_t, StackAlloc salloc, Fn && fn, Args && ... args) :
+    execution_context( std::allocator_arg_t, StackAlloc && salloc, Fn && fn, Args && ... args) :
         // deferred execution of fn and its arguments
         // arguments are stored in std::tuple<>
         // non-type template parameter pack via std::index_sequence_for<>
         // preserves the number of arguments
         // used to extract the function arguments from std::tuple<>
-        ptr_{ create_context( salloc,
+        ptr_{ create_context( std::forward< StackAlloc >( salloc),
                               std::forward< Fn >( fn),
                               std::forward< Args >( args) ...) } {
         ptr_->resume( ptr_.get() );
@@ -390,13 +390,13 @@ public:
               typename Fn,
               typename ... Args
     >
-    execution_context( std::allocator_arg_t, preallocated palloc, StackAlloc salloc, Fn && fn, Args && ... args) :
+    execution_context( std::allocator_arg_t, preallocated palloc, StackAlloc && salloc, Fn && fn, Args && ... args) :
         // deferred execution of fn and its arguments
         // arguments are stored in std::tuple<>
         // non-type template parameter pack via std::index_sequence_for<>
         // preserves the number of arguments
         // used to extract the function arguments from std::tuple<>
-        ptr_{ create_context( palloc, salloc,
+        ptr_{ create_context( palloc, std::forward< StackAlloc >( salloc),
                               std::forward< Fn >( fn),
                               std::forward< Args >( args) ...) } {
         ptr_->resume( ptr_.get() );


### PR DESCRIPTION
In a project of mine I have a non-copyable StackAlloc-type. I changed StackAlloc to use perfect forwarding so that it can be moved instead of copied.