### PR TITLE
Fix braces in execution_context.cpp

### DIFF
--- a/src/execution_context.cpp
+++ b/src/execution_context.cpp
@@ -14,9 +14,10 @@
 
 namespace boost {
 namespace context {
-namespace detail {
 
 #if !defined(BOOST_NO_CXX11_THREAD_LOCAL)
+
+namespace detail {
 
 ecv1_activation_record::ptr_t &
 ecv1_activation_record::current() noexcept {


### PR DESCRIPTION
When BOOST_NO_CXX11_THREAD_LOCAL is defined.