### PR TITLE
Duplicate alias should be missing GCC alias

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -318,7 +318,7 @@ alias asm_sources
      <address-model>32
      <architecture>power
      <binary-format>elf
-     <toolset>clang
+     <toolset>gcc
    ;
 
 alias asm_sources


### PR DESCRIPTION
Turn duplicate sysv-power-32-elf-clang alias into missing sysv-power-32-elf-gcc alias