### PR TITLE
Fixed a bug for armv7 by adding .syntax unifed to assembly sources

### DIFF
--- a/src/asm/jump_arm_aapcs_elf_gas.S
+++ b/src/asm/jump_arm_aapcs_elf_gas.S
@@ -43,6 +43,7 @@
 .globl jump_fcontext
 .align 2
 .type jump_fcontext,%function
+.syntax unified
 jump_fcontext:
     @ save LR as PC
     push {lr}

--- a/src/asm/make_arm_aapcs_elf_gas.S
+++ b/src/asm/make_arm_aapcs_elf_gas.S
@@ -43,6 +43,7 @@
 .globl make_fcontext
 .align 2
 .type make_fcontext,%function
+.syntax unified
 make_fcontext:
     @ shift address in A1 to lower 16 byte boundary
     bic  a1, a1, #15

--- a/src/asm/ontop_arm_aapcs_elf_gas.S
+++ b/src/asm/ontop_arm_aapcs_elf_gas.S
@@ -43,6 +43,7 @@
 .globl ontop_fcontext
 .align 2
 .type ontop_fcontext,%function
+.syntax unified
 ontop_fcontext:
     @ save LR as PC
     push {lr}


### PR DESCRIPTION
I got errors compiling boost on armhf with following errors:

```
libs/context/src/asm/make_arm_aapcs_elf_gas.S: Assembler messages:
libs/context/src/asm/make_arm_aapcs_elf_gas.S:47: Error: unshifted register required -- `bic a1,a1,#15'
libs/context/src/asm/make_arm_aapcs_elf_gas.S:56: Error: immediate value out of range
libs/context/src/asm/ontop_arm_aapcs_elf_gas.S: Assembler messages:
libs/context/src/asm/ontop_arm_aapcs_elf_gas.S:49: Error: invalid register list to push/pop instruction -- `push {a1,v1-v8,lr}'
libs/context/src/asm/ontop_arm_aapcs_elf_gas.S:75: Error: invalid register list to push/pop instruction -- `pop {a1,v1-v8,lr}'
...skipped <pbin.v2/libs/context/build/gcc-8.2.0/release/link-static/threading-multi>libboost_context.a(clean) for lack of <pbin.v2/libs/context/build/gcc-8.2.0/release/link-static/threading-multi>asm/make_arm_aapcs_elf_gas.o...
...skipped <pbin.v2/libs/context/build/gcc-8.2.0/release/link-static/threading-multi>libboost_context.a for lack of <pbin.v2/libs/context/build/gcc-8.2.0/release/link-static/threading-multi>asm/make_arm_aapcs_elf_gas.o...
```
...and fixed it by adding the directive `.syntax unified`

I'm not sure that it fixes the issue or introduces other problems, but at least it compiles cleanly with gcc-8.2.0.