### PR TITLE
Add missing BOST_CONTEXT_DECL in stack_context

### DIFF
--- a/include/boost/context/stack_context.hpp
+++ b/include/boost/context/stack_context.hpp
@@ -21,7 +21,7 @@ namespace boost {
 namespace context {
 
 #if ! defined(BOOST_CONTEXT_NO_CXX11)
-struct stack_context {
+struct BOOST_CONTEXT_DECL stack_context {
 # if defined(BOOST_USE_SEGMENTED_STACKS)
     typedef void *  segments_context[BOOST_CONTEXT_SEGMENTS];
 # endif
@@ -36,7 +36,7 @@ struct stack_context {
 # endif
 };
 #else
-struct stack_context {
+struct BOOST_CONTEXT_DECL stack_context {
 # if defined(BOOST_USE_SEGMENTED_STACKS)
     typedef void *  segments_context[BOOST_CONTEXT_SEGMENTS];
 # endif


### PR DESCRIPTION
Fixes a dll-interface warning in MSVC.