### PR TITLE
Fix jump_i386_sysv_macho writing garbage to the x87 control word

### DIFF
--- a/src/asm/jump_i386_sysv_macho_gas.S
+++ b/src/asm/jump_i386_sysv_macho_gas.S
@@ -54,7 +54,8 @@ _jump_fcontext:
 
     /* return parent fcontext_t */
     movl  %ecx, %eax
-
+    /* returned data is stored in EDX */ 
+ 
     movl  0x18(%esp), %ecx  /* restore EIP */
 
 #if !defined(BOOST_USE_TSX)

--- a/src/asm/jump_i386_sysv_macho_gas.S
+++ b/src/asm/jump_i386_sysv_macho_gas.S
@@ -54,8 +54,6 @@ _jump_fcontext:
 
     /* return parent fcontext_t */
     movl  %ecx, %eax
-    /* returned data is stored in EDX */
-    movl %edx, 0x4(%eax)
 
     movl  0x18(%esp), %ecx  /* restore EIP */
 


### PR DESCRIPTION
I'm running into crashes on 32bit iOS devices caused by the x87 FPU control word not being saved correctly.
I'm not familiar with the boost.context implementation, but it seems this line is overwriting the control word right before it is loaded.

I think the macho code may have been modeled after the elf version,
which writes the returned transport_t through a pointer in eax,
however macho is expected to return its transport_t result in eax:edx.

The macho code mistakenly wrote its "data" return value through eax.
This happens to overwrite the saved fc_x87_cw before it is loaded,
resulting in floating-point exceptions and crashes in unrelated code.

Does that sound about right?