### PR TITLE
Fix ABI violation on ppc64 ELFv2, fixes #72

### DIFF
--- a/src/asm/ontop_ppc64_sysv_elf_gas.S
+++ b/src/asm/ontop_ppc64_sysv_elf_gas.S
@@ -174,6 +174,9 @@ ontop_fcontext:
     # restore CTR
     mtctr  %r5
 
+    # store cb entrypoint in %r12, used for TOC calculation
+    mr %r12, %r5
+
     # copy transfer_t into ontop_fn arg registers
     mr  %r3, %r7
     # arg pointer already in %r4


### PR DESCRIPTION
The existing ontop_fcontext implementation for ppc64 ELFv2
violates the ABI by not storing the callback entry address
in %r12 before branching. This results in crashes on this
platform.

This commit addresses this and allows the context library
to function as expected on ppc64 platforms using the ELFv2 ABI.

The OpenPOWER ELFv2 ABI states on page 41, section 2.2.1.1: "r12 [...] Function entry address at the global entry point."