### PR TITLE
Fix compilation with MSVC for ARM

### DIFF
--- a/include/boost/context/detail/prefetch.hpp
+++ b/include/boost/context/detail/prefetch.hpp
@@ -18,7 +18,7 @@
 #include <immintrin.h>
 #endif
 
-#if BOOST_COMP_MSVC
+#if BOOST_COMP_MSVC && !defined(_M_ARM) && !defined(_M_ARM64)
 #include <mmintrin.h>
 #endif
 
@@ -44,7 +44,7 @@ void prefetch( void * addr) {
     // L1 cache : hint == _MM_HINT_T0
     _mm_prefetch( (const char *)addr, _MM_HINT_T0);
 }
-#elif BOOST_COMP_MSVC
+#elif BOOST_COMP_MSVC && !defined(_M_ARM) && !defined(_M_ARM64)
 #define BOOST_HAS_PREFETCH 1
 BOOST_FORCEINLINE
 void prefetch( void * addr) {


### PR DESCRIPTION
Much like https://github.com/boostorg/type_traits/pull/106, only allow
x86-specific intrinsics when targetting x86-like architectures.