### PR TITLE
Fix exports for 32-bit GNU assembler files targeting Windows.

### DIFF
--- a/src/asm/jump_i386_ms_pe_gas.asm
+++ b/src/asm/jump_i386_ms_pe_gas.asm
@@ -114,4 +114,4 @@ _jump_fcontext:
     jmp *%ecx
 
 .section .drectve
-.ascii " -export:\"jump_fcontext\""
+.ascii " -export:\"_jump_fcontext\""

--- a/src/asm/make_i386_ms_pe_gas.asm
+++ b/src/asm/make_i386_ms_pe_gas.asm
@@ -144,4 +144,4 @@ finish:
 .def	__exit;	.scl	2;	.type	32;	.endef  /* standard C library function */
 
 .section .drectve
-.ascii " -export:\"make_fcontext\""
+.ascii " -export:\"_make_fcontext\""

--- a/src/asm/ontop_i386_ms_pe_gas.asm
+++ b/src/asm/ontop_i386_ms_pe_gas.asm
@@ -122,4 +122,4 @@ _ontop_fcontext:
     jmp  *%ecx
 
 .section .drectve
-.ascii " -export:\"ontop_fcontext\""
+.ascii " -export:\"_ontop_fcontext\""


### PR DESCRIPTION
The incorrect exports can cause linker issues (at least when using LLVM's lld-link) claiming that these primitives are not available.