### PR TITLE
Mark 32-bit GNU assembly files targeting Windows as safeseh compatible

### DIFF
--- a/src/asm/jump_i386_ms_pe_gas.asm
+++ b/src/asm/jump_i386_ms_pe_gas.asm
@@ -26,6 +26,12 @@
 .file	"jump_i386_ms_pe_gas.asm"
 .text
 .p2align 4,,15
+
+/* mark as using no unregistered SEH handlers */
+.globl	@feat.00
+.def	@feat.00;	.scl	3;	.type	0;	.endef
+.set    @feat.00,   1
+
 .globl	_jump_fcontext
 .def	_jump_fcontext;	.scl	2;	.type	32;	.endef
 _jump_fcontext:

--- a/src/asm/make_i386_ms_pe_gas.asm
+++ b/src/asm/make_i386_ms_pe_gas.asm
@@ -26,6 +26,12 @@
 .file	"make_i386_ms_pe_gas.asm"
 .text
 .p2align 4,,15
+
+/* mark as using no unregistered SEH handlers */
+.globl	@feat.00
+.def	@feat.00;	.scl	3;	.type	0;	.endef
+.set    @feat.00,   1
+
 .globl	_make_fcontext
 .def	_make_fcontext;	.scl	2;	.type	32;	.endef
 _make_fcontext:

--- a/src/asm/ontop_i386_ms_pe_gas.asm
+++ b/src/asm/ontop_i386_ms_pe_gas.asm
@@ -26,6 +26,12 @@
 .file	"ontop_i386_ms_pe_gas.asm"
 .text
 .p2align 4,,15
+
+/* mark as using no unregistered SEH handlers */
+.globl	@feat.00
+.def	@feat.00;	.scl	3;	.type	0;	.endef
+.set    @feat.00,   1
+
 .globl	_ontop_fcontext
 .def	_ontop_fcontext;	.scl	2;	.type	32;	.endef
 _ontop_fcontext:


### PR DESCRIPTION
We set the LSB of the magic symbol @feat.00 to 1. This symbol is used for compiler-linker communication, and the LSB expresses that an object file has opted into "safeseh"; any SEH handlers used in this file must be listed in the .sxdata section.

Since we don't register any SEH handlers in these files, this is trivially satisfied.

Reference: [the PE-COFF specification](https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#the-sxdata-section).