### PR TITLE
Fix non-PIC in RISC-V assembly

### DIFF
--- a/src/asm/make_riscv64_sysv_elf_gas.S
+++ b/src/asm/make_riscv64_sysv_elf_gas.S
@@ -75,7 +75,7 @@ make_fcontext:
 
     # save address of finish as return-address for context-function
     # will be entered after context-function returns (RA register)
-    la  a4, finish
+    lla  a4, finish
     sd  a4, 0xc0(a0)
 
     ret // return pointer to context-data (a0)
@@ -84,7 +84,7 @@ finish:
     # exit code is zero
     li  a0, 0
     # exit application
-    tail  _exit
+    tail  _exit@plt
 
 .size   make_fcontext,.-make_fcontext
 # Mark that we don't need executable stack.


### PR DESCRIPTION
Since this ends up in a shared library we should use a PLT call.  Also,
the finish label is local, so we can use lla instead of la.