### PR TITLE
Use OSPLAT MIPS32/MIPS64 to set different ABI

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -75,7 +75,8 @@ local rule default_abi ( )
     if [ os.name ] = "NT" { tmp = ms ; }
     else if [ os.name ] = "CYGWIN" { tmp = ms ; }
     else if [ os.platform ] = "ARM" { tmp = aapcs ; }
-    else if [ os.platform ] = "MIPS" { tmp = o32 ; }
+    else if [ os.platform ] = "MIPS32" { tmp = o32 ; }
+    else if [ os.platform ] = "MIPS64" { tmp = n64 ; }
     return $(tmp) ;
 }
 


### PR DESCRIPTION
We should set abi for 64bit as n64, and 32bit for o32.
This patch depends on the patch of boost/build.