### PR TITLE
mips64/n64: .align 3

### DIFF
--- a/src/asm/jump_mips64_n64_elf_gas.S
+++ b/src/asm/jump_mips64_n64_elf_gas.S
@@ -48,7 +48,7 @@
 .file "jump_mips64_n64_elf_gas.S"
 .text
 .globl jump_fcontext
-.align 2
+.align 3
 .type jump_fcontext,@function
 .ent jump_fcontext
 jump_fcontext:

--- a/src/asm/make_mips64_n64_elf_gas.S
+++ b/src/asm/make_mips64_n64_elf_gas.S
@@ -48,7 +48,7 @@
 .file "make_mips64_n64_elf_gas.S"
 .text
 .globl make_fcontext
-.align 2
+.align 3
 .type make_fcontext,@function
 .ent make_fcontext
 make_fcontext:

--- a/src/asm/ontop_mips64_n64_elf_gas.S
+++ b/src/asm/ontop_mips64_n64_elf_gas.S
@@ -48,7 +48,7 @@
 .file "ontop_mips64_n64_elf_gas.S"
 .text
 .globl ontop_fcontext
-.align 2
+.align 3
 .type ontop_fcontext,@function
 .ent ontop_fcontext
 ontop_fcontext:


### PR DESCRIPTION
The right align for mips64/n64 is 3 instead of 2.