### PR TITLE
Fix gcc -Wunused-variable argument when compiling with -DNDEBUG (and …

### DIFF
--- a/include/boost/context/posix/protected_fixedsize_stack.hpp
+++ b/include/boost/context/posix/protected_fixedsize_stack.hpp
@@ -20,6 +20,7 @@ extern "C" {
 
 #include <boost/assert.hpp>
 #include <boost/config.hpp>
+#include <boost/core/ignore_unused.hpp>
 
 #include <boost/context/detail/config.hpp>
 #include <boost/context/stack_context.hpp>
@@ -67,12 +68,9 @@ public:
         if ( MAP_FAILED == vp) throw std::bad_alloc();
 
         // conforming to POSIX.1-2001
-#if defined(BOOST_DISABLE_ASSERTS)
-        ::mprotect( vp, traits_type::page_size(), PROT_NONE);
-#else
         const int result( ::mprotect( vp, traits_type::page_size(), PROT_NONE) );
+        boost::ignore_unused(result);
         BOOST_ASSERT( 0 == result);
-#endif
 
         stack_context sctx;
         sctx.size = size__;

--- a/include/boost/context/windows/protected_fixedsize_stack.hpp
+++ b/include/boost/context/windows/protected_fixedsize_stack.hpp
@@ -16,6 +16,7 @@ extern "C" {
 #include <new>
 
 #include <boost/config.hpp>
+#include <boost/core/ignore_unused.hpp>
 
 #include <boost/context/detail/config.hpp>
 #include <boost/context/stack_context.hpp>
@@ -53,14 +54,10 @@ public:
         if ( ! vp) throw std::bad_alloc();
 
         DWORD old_options;
-#if defined(BOOST_DISABLE_ASSERTS)
-        ::VirtualProtect(
-            vp, traits_type::page_size(), PAGE_READWRITE | PAGE_GUARD /*PAGE_NOACCESS*/, & old_options);
-#else
         const BOOL result = ::VirtualProtect(
             vp, traits_type::page_size(), PAGE_READWRITE | PAGE_GUARD /*PAGE_NOACCESS*/, & old_options);
+        boost::ignore_unused(result);
         BOOST_ASSERT( FALSE != result);
-#endif
 
         stack_context sctx;
         sctx.size = size__;


### PR DESCRIPTION
…without -DBOOST_DISABLE_ASSERT).