### PR TITLE
Fixes for x32 ABI.

### DIFF
--- a/src/asm/jump_x86_64_sysv_elf_gas.S
+++ b/src/asm/jump_x86_64_sysv_elf_gas.S
@@ -67,10 +67,20 @@ jump_fcontext:
     leaq  0x40(%rsp), %rsp /* prepare stack */
 
     /* return transfer_t from jump */
+#if !defined(_ILP32)
     /* RAX == fctx, RDX == data */
     movq  %rsi, %rdx
+#else
+    /* RAX == data:fctx */
+    salq  $32, %rsi
+    orq   %rsi, %rax
+#endif
     /* pass transfer_t as first arg in context function */
+#if !defined(_ILP32)
     /* RDI == fctx, RSI == data */
+#else
+    /* RDI == data:fctx */
+#endif
     movq  %rax, %rdi
 
     /* indirect jump to context */

--- a/src/asm/ontop_x86_64_sysv_elf_gas.S
+++ b/src/asm/ontop_x86_64_sysv_elf_gas.S
@@ -68,10 +68,20 @@ ontop_fcontext:
     leaq  0x38(%rsp), %rsp /* prepare stack */
 
     /* return transfer_t from jump */
+#if !defined(_ILP32)
     /* RAX == fctx, RDX == data */
     movq  %rsi, %rdx
+#else
+    /* RAX == data:fctx */
+    salq  $32, %rsi
+    orq   %rsi, %rax
+#endif
     /* pass transfer_t as first arg in context function */
+#if !defined(_ILP32)
     /* RDI == fctx, RSI == data */
+#else
+    /* RDI == data:fctx */
+#endif
     movq  %rax, %rdi
 
     /* keep return-address on stack */


### PR DESCRIPTION
In the x32 ABI, pointers take up 4 bytes, so a structure containing two pointers is passed and returned in a single 8-byte register.

Changes required to build for the x32 ABI in the first place are not part of this pull request: that is the subject of https://github.com/boostorg/build/issues/388. I have tested this PR on top of local modifications that bypass Boost's forced overriding of compiler flags.