### PR TITLE
Revert "Fix exports for 32-bit GNU assembler files targeting Windows."

### DIFF
--- a/src/asm/jump_i386_ms_pe_gas.asm
+++ b/src/asm/jump_i386_ms_pe_gas.asm
@@ -120,4 +120,4 @@ _jump_fcontext:
     jmp *%ecx
 
 .section .drectve
-.ascii " -export:\"_jump_fcontext\""
+.ascii " -export:\"jump_fcontext\""

--- a/src/asm/make_i386_ms_pe_gas.asm
+++ b/src/asm/make_i386_ms_pe_gas.asm
@@ -150,4 +150,4 @@ finish:
 .def	__exit;	.scl	2;	.type	32;	.endef  /* standard C library function */
 
 .section .drectve
-.ascii " -export:\"_make_fcontext\""
+.ascii " -export:\"make_fcontext\""

--- a/src/asm/ontop_i386_ms_pe_gas.asm
+++ b/src/asm/ontop_i386_ms_pe_gas.asm
@@ -128,4 +128,4 @@ _ontop_fcontext:
     jmp  *%ecx
 
 .section .drectve
-.ascii " -export:\"_ontop_fcontext\""
+.ascii " -export:\"ontop_fcontext\""


### PR DESCRIPTION
This reverts 85783e8, as the wrong linker was used

Closes #136