### PR TITLE
Use integer math instead of floating-point to compute number of pages

### DIFF
--- a/include/boost/context/posix/protected_fixedsize_stack.hpp
+++ b/include/boost/context/posix/protected_fixedsize_stack.hpp
@@ -51,10 +51,7 @@ public:
 
     stack_context allocate() {
         // calculate how many pages are required
-        const std::size_t pages(        
-            static_cast< std::size_t >(
-                std::ceil(
-                    static_cast< float >( size_) / traits_type::page_size() ) ) );
+        const std::size_t pages = (size_ + traits_type::page_size() - 1) / traits_type::page_size();
         // add one page at bottom that will be used as guard-page
         const std::size_t size__ = ( pages + 1) * traits_type::page_size();
 

--- a/include/boost/context/windows/protected_fixedsize_stack.hpp
+++ b/include/boost/context/windows/protected_fixedsize_stack.hpp
@@ -43,10 +43,7 @@ public:
 
     stack_context allocate() {
         // calculate how many pages are required
-        const std::size_t pages(        
-            static_cast< std::size_t >(
-                std::ceil(
-                    static_cast< float >( size_) / traits_type::page_size() ) ) );
+        const std::size_t pages = (size_ + traits_type::page_size() - 1) / traits_type::page_size()
         // add one page at bottom that will be used as guard-page
         const std::size_t size__ = ( pages + 1) * traits_type::page_size();
 


### PR DESCRIPTION
The previous math can go wrong if size_ cannot be exactly expressed with fp32.