### PR TITLE
In cygwin we want to use UCONTEXT

### DIFF
--- a/include/boost/context/detail/config.hpp
+++ b/include/boost/context/detail/config.hpp
@@ -30,6 +30,10 @@
 # define BOOST_CONTEXT_DECL
 #endif
 
+#if ! defined(BOOST_USE_UCONTEXT) && defined(__CYGWIN__)
+# define BOOST_USE_UCONTEXT
+#endif
+
 #if ! defined(BOOST_CONTEXT_SOURCE) && ! defined(BOOST_ALL_NO_LIB) && ! defined(BOOST_CONTEXT_NO_LIB)
 # define BOOST_LIB_NAME boost_context
 # if defined(BOOST_ALL_DYN_LINK) || defined(BOOST_CONTEXT_DYN_LINK)


### PR DESCRIPTION
Crash otherwise.

I haven't tried winfibers.

I think this should fix https://github.com/boostorg/coroutine2/issues/34. Is this the kind of patch that could get in? Or how else?