### PR TITLE
Add arm and arm64 into combined asm codes

### DIFF
--- a/src/asm/jump_combined_sysv_macho_gas.S
+++ b/src/asm/jump_combined_sysv_macho_gas.S
@@ -15,6 +15,10 @@
     #include "jump_ppc32_sysv_macho_gas.S"
 #elif defined(__ppc64__)
     #include "jump_ppc64_sysv_macho_gas.S"
+#elif defined(__arm__)
+    #include "jump_arm_aapcs_macho_gas.S"
+#elif defined(__arm64__)
+    #include "jump_arm64_aapcs_macho_gas.S"
 #else
     #error "No arch's"
 #endif

--- a/src/asm/make_combined_sysv_macho_gas.S
+++ b/src/asm/make_combined_sysv_macho_gas.S
@@ -15,6 +15,10 @@
     #include "make_ppc32_sysv_macho_gas.S"
 #elif defined(__ppc64__)
     #include "make_ppc64_sysv_macho_gas.S"
+#elif defined(__arm__)
+    #include "make_arm_aapcs_macho_gas.S"
+#elif defined(__arm64__)
+    #include "make_arm64_aapcs_macho_gas.S"
 #else
     #error "No arch's"
 #endif

--- a/src/asm/ontop_combined_sysv_macho_gas.S
+++ b/src/asm/ontop_combined_sysv_macho_gas.S
@@ -15,6 +15,10 @@
     #include "ontop_ppc32_sysv_macho_gas.S"
 #elif defined(__ppc64__)
     #include "ontop_ppc64_sysv_macho_gas.S"
+#elif defined(__arm__)
+    #include "ontop_arm_aapcs_macho_gas.S"
+#elif defined(__arm64__)
+    #include "ontop_arm64_aapcs_macho_gas.S"
 #else
     #error "No arch's"
 #endif


### PR DESCRIPTION
Apple silicon M1 uses arm64 architecture, this commit will add arm and arm64 architecture into combined asm code in order to support newer apple's machine in combined asm codes.