### PR TITLE
make_fcontext darwin arm64 removes workaround LLVM IR supports label …

### DIFF
--- a/src/asm/make_arm64_aapcs_macho_gas.S
+++ b/src/asm/make_arm64_aapcs_macho_gas.S
@@ -66,12 +66,7 @@ _make_fcontext:
     ; store address as a PC to jump in
     str  x2, [x0, #0xa0]
 
-    ; compute abs address of label finish
-    ; 0x0c = 3 instructions * size (4) before label 'finish'
-
-    ; TODO: Numeric offset since llvm still does not support labels in ADR. Fix:
-    ;       http://lists.cs.uiuc.edu/pipermail/llvm-commits/Week-of-Mon-20140407/212336.html
-    adr  x1, 0x0c
+    adr  x1, finish
 
     ; save address of finish as return-address for context-function
     ; will be entered after context-function returns (LR register)


### PR DESCRIPTION
…to adr ins since couple of years already