### PR TITLE
Fix missing semicolon

### DIFF
--- a/include/boost/context/windows/protected_fixedsize_stack.hpp
+++ b/include/boost/context/windows/protected_fixedsize_stack.hpp
@@ -43,7 +43,7 @@ public:
 
     stack_context allocate() {
         // calculate how many pages are required
-        const std::size_t pages = (size_ + traits_type::page_size() - 1) / traits_type::page_size()
+        const std::size_t pages = (size_ + traits_type::page_size() - 1) / traits_type::page_size();
         // add one page at bottom that will be used as guard-page
         const std::size_t size__ = ( pages + 1) * traits_type::page_size();
 


### PR DESCRIPTION
The error was introduced in commit 3f3d358 and present in boost 1.76 release.