### PR TITLE
Fix 64-bit XCOFF assembly

### DIFF
--- a/src/asm/jump_ppc64_sysv_xcoff_gas.S
+++ b/src/asm/jump_ppc64_sysv_xcoff_gas.S
@@ -12,7 +12,7 @@
     # reserve space on stack
     subi  1, 1, 184
 
-    std  13, 0(1)  # save R13
+    std  2, 0(1)  # save TOC
     std  14, 8(1)  # save R14
     std  15, 16(1)  # save R15
     std  16, 24(1)  # save R16
@@ -48,7 +48,7 @@
     # restore RSP (pointing to context-data) from R4
     mr  1, 4
 
-    ld  13, 0(1)  # restore R13
+    ld  2, 0(1)  # restore TOC
     ld  14, 8(1)  # restore R14
     ld  15, 16(1)  # restore R15
     ld  16, 24(1)  # restore R16
@@ -84,9 +84,21 @@
     # adjust stack
     addi  1, 1, 184
 
+    # zero in r3 indicates first jump to context-function
+    cmpdi 3, 0
+    beq use_entry_arg
+
     # return transfer_t
     std  6, 0(3)
     std  5, 8(3)
+
+    # jump to context
+    bctr
+
+use_entry_arg:
+    # copy transfer_t into transfer_fn arg registers
+    mr  3, 6
+    mr  4, 5
 
     # jump to context
     bctr

--- a/src/asm/make_ppc64_sysv_xcoff_gas.S
+++ b/src/asm/make_ppc64_sysv_xcoff_gas.S
@@ -15,23 +15,25 @@
 
     # first arg of make_fcontext() == top address of context-function
     # shift address in R3 to lower 16 byte boundary
-    clrrwi  3, 3, 4
+    clrrdi  3, 3, 4
 
     # reserve space for context-data on context-stack
     # including 64 byte of linkage + parameter area (R1 % 16 == 0)
     subi  3, 3, 248
 
     # third arg of make_fcontext() == address of context-function
-    stw  5, 176(3)
+    ld   4, 0(5)
+    std  4, 176(3)
+    # save TOC of context-function
+    ld   4, 8(5)
+    std  4, 0(3)
 
     # set back-chain to zero
     li   0, 0
     std  0, 184(3)
 
-    # compute address of returned transfer_t
-    addi 0, 3, 232
-    mr   4, 0
-    std  4, 152(3)
+    # zero in r3 indicates first jump to context-function
+    std  0, 152(3)
 
     # load LR
     mflr  0
@@ -46,7 +48,7 @@
     mtlr  0
     # save address of finish as return-address for context-function
     # will be entered after context-function returns
-    stw  4, 168(3)
+    std  4, 168(3)
 
     # restore return address from R6
     mtlr  6
@@ -57,9 +59,9 @@
     # save return address into R0
     mflr  0
     # save return address on stack, set up stack frame
-    stw  0, 8(1)
+    std  0, 8(1)
     # allocate stack space, R1 % 16 == 0
-    stwu  1, -32(1)
+    stdu  1, -32(1)
 
     # exit code is zero
     li  3, 0


### PR DESCRIPTION
It should almost exactly match the ELFv1 ABI code now, except with IBM assembler syntax.

Tested with [PHP fibres](https://github.com/php/php-src/pull/7338). Fixes #180