### PR TITLE
Add support for building on riscv64 with Clang

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -430,6 +430,17 @@ alias asm_sources
      <address-model>64
      <architecture>riscv
      <binary-format>elf
+     <toolset>clang
+   ;
+
+alias asm_sources
+   : asm/make_riscv64_sysv_elf_gas.S
+     asm/jump_riscv64_sysv_elf_gas.S
+     asm/ontop_riscv64_sysv_elf_gas.S
+   : <abi>sysv
+     <address-model>64
+     <architecture>riscv
+     <binary-format>elf
      <toolset>gcc
    ;
 


### PR DESCRIPTION
Tested on OpenBSD -current riscv64 with Clang 11.1.0.