### PR TITLE
CI: Test multiple architectures

### DIFF
--- a/.github/workflows/multi.yml
+++ b/.github/workflows/multi.yml
@@ -1,0 +1,142 @@
+#==============================================================================
+#   Copyright (c) 2022 Nikita Kniazev
+#
+#   Use, modification and distribution is subject to the Boost Software
+#   License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+#   http://www.boost.org/LICENSE_1_0.txt)
+#==============================================================================
+
+name: Multiarch CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  emulated:
+    name: ${{ matrix.arch || 'native' }} ${{ matrix.os || matrix.distro || 'bullseye' }} ${{ matrix.toolset }}
+    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm64
+          - armel
+          - armhf
+          - i386
+          - mipsel
+          - mips64el
+          - ppc64el
+          - s390x
+        include:
+          - { arch: mips, distro: buster }
+
+    steps:
+      - name: Checkout Boost super-repo
+        env:
+          REF: ${{ github.base_ref || github.ref_name }}
+          BRANCH: ${{ env.REF != 'develop' && env.REF != 'master' && 'develop' || env.REF }}
+        shell: bash
+        run: git clone -j10 --depth=1 --branch=${{ env.BRANCH }} --no-tags
+             https://github.com/boostorg/boost.git '${{ github.workspace }}'
+
+      - name: Checkout minimal Boost
+        run: git submodule update --init --depth 1 --jobs 10 --single-branch --
+          tools/build
+          libs/config
+          tools/boostdep
+
+      - name: Checkout the commit
+        uses: actions/checkout@v3
+        with:
+          path: libs/context
+
+      - name: Checkout library dependencies
+        run: python tools/boostdep/depinst/depinst.py --git_args "--jobs 10" context
+
+      - name: "Setup QEMU and Docker"
+        if: matrix.arch
+        run: |
+          set -eu
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get -o Acquire::Retries=3 -y install qemu-user-static
+          docker pull multiarch/debian-debootstrap:${{ matrix.arch }}-${{ matrix.distro || 'bullseye' }}
+
+      - name: "Building and testing on ${{ matrix.arch }}"
+        uses: addnab/docker-run-action@v3
+        if: matrix.arch
+        with:
+          image: multiarch/debian-debootstrap:${{ matrix.arch }}-${{ matrix.distro || 'bullseye' }}
+          options: -v ${{ github.workspace }}:/boost-root -w /boost-root
+          run: |
+            set -eu
+            echo "::group::Install GCC"
+              apt-get -o Acquire::Retries=3 update
+              apt-get -o Acquire::Retries=3 -yq --no-install-suggests --no-install-recommends install g++
+            echo "::endgroup::"
+            echo "::group::GCC info"
+              g++ -v
+            echo "::endgroup::"
+            echo "::group::Build B2"
+              ./bootstrap.sh
+            echo "::endgroup::"
+            echo "::group::Toolset info"
+              ./b2 libs/config/test//print_config_info
+            echo "::endgroup::"
+
+            echo "::group::Run tests"
+              ./b2 libs/context/test
+            echo "::endgroup::"
+
+  native:
+    name: native ${{ matrix.os }} ${{ matrix.toolset }}
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu' ]
+        toolset: [ 'gcc', 'clang' ]
+        include:
+          - { os: macos, toolset: darwin, options: cxxstd=17 }
+          - { os: macos, toolset: clang, options: cxxstd=17 }
+          - { os: windows, toolset: gcc }
+          - { os: windows, toolset: clang-win, options: embed-manifest-via=linker }
+
+    steps:
+      - name: Checkout Boost super-repo
+        env:
+          REF: ${{ github.base_ref || github.ref_name }}
+          BRANCH: ${{ env.REF != 'develop' && env.REF != 'master' && 'develop' || env.REF }}
+        shell: bash
+        run: git clone -j10 --depth=1 --branch=${{ env.BRANCH }} --no-tags
+             https://github.com/boostorg/boost.git '${{ github.workspace }}'
+
+      - name: Checkout minimal Boost
+        run: git submodule update --init --depth 1 --jobs 10 --single-branch --
+          tools/build
+          libs/config
+          tools/boostdep
+
+      - name: Checkout the commit
+        uses: actions/checkout@v3
+        with:
+          path: libs/context
+
+      - name: Checkout library dependencies
+        run: python tools/boostdep/depinst/depinst.py --git_args "--jobs 10" context
+
+      - name: Bootstrap via bash
+        shell: bash
+        if: ${{ runner.os != 'Windows' }}
+        run: ./bootstrap.sh && echo "`pwd`" >> $GITHUB_PATH
+      - name: Bootstrap via bat
+        shell: pwsh
+        if: ${{ runner.os == 'Windows' }}
+        run: .\bootstrap.bat && echo "$pwd" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Dump toolset info
+        run: b2 libs/config/test//print_config_info toolset=${{ matrix.toolset }} ${{ matrix.options }}
+
+      - name: Build and test
+        run: b2 libs/context/test toolset=${{ matrix.toolset }} ${{ matrix.options }}

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -13,6 +13,7 @@ import os ;
 import testing ;
 import toolset ;
 import ../../config/checks/config : requires ;
+using flags ;
 
 project boost/context/test
     : requirements
@@ -48,19 +49,13 @@ rule native-impl ( properties * )
     return $(result) ;
 }
 
-rule segmented-stack ( properties * )
-{
-    local result  ;
-    if ( <toolset>gcc in $(properties) )
-    {
-        result = <segmented-stacks>on ;
-    }
-    else
-    {
-        result = <build>no ;
-    }
-    return $(result) ;
-}
+obj is_libstdcxx : is_libstdcxx.cpp ;
+explicit is_libstdcxx ;
+
+local only-when-segmented-stack-is-available =
+    [ check-has-flag <cxxflags>-fsplit-stack : <segmented-stacks>on : <build>no ]
+    [ check-target-builds is_libstdcxx "is libstdc++" : : <build>no ]
+  ;
 
 test-suite minimal :
 [ run test_invoke.cpp :
@@ -134,7 +129,7 @@ test-suite minimal :
 [ run test_fiber.cpp :
     : :
     <context-impl>ucontext
-    <conditional>@segmented-stack
+    $(only-when-segmented-stack-is-available)
     [ requires cxx11_auto_declarations
                cxx11_constexpr
                cxx11_defaulted_functions
@@ -189,7 +184,7 @@ test-suite minimal :
 [ run test_callcc.cpp :
     : :
     <context-impl>ucontext
-    <conditional>@segmented-stack
+    $(only-when-segmented-stack-is-available)
     [ requires cxx11_auto_declarations
                cxx11_constexpr
                cxx11_defaulted_functions

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -17,7 +17,6 @@ using flags ;
 
 project boost/context/test
     : requirements
-      <library>../../test/build//boost_unit_test_framework
       <library>/boost/context//boost_context
       <target-os>linux,<toolset>gcc,<segmented-stacks>on:<cxxflags>-fsplit-stack
       <target-os>linux,<toolset>gcc,<segmented-stacks>on:<cxxflags>-DBOOST_USE_SEGMENTED_STACKS

--- a/test/is_libstdcxx.cpp
+++ b/test/is_libstdcxx.cpp
@@ -1,0 +1,12 @@
+//          Copyright Nikita Kniazev 2022.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/config.hpp>
+
+#ifndef BOOST_LIBSTDCXX_VERSION
+# error "Not libstdc++"
+#endif
+
+int main() {}

--- a/test/test_apply.cpp
+++ b/test/test_apply.cpp
@@ -13,10 +13,12 @@
 #include <utility>
 
 #include <boost/assert.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #include <boost/context/detail/apply.hpp>
 #include <boost/context/detail/config.hpp>
+
+#define BOOST_CHECK_EQUAL(a, b) BOOST_TEST_EQ(a, b)
 
 namespace ctx = boost::context;
 
@@ -192,18 +194,15 @@ void test7() {
     }
 }
 
-boost::unit_test::test_suite * init_unit_test_suite( int, char* [])
+int main()
 {
-    boost::unit_test::test_suite * test =
-        BOOST_TEST_SUITE("Boost.Context: apply test suite");
+    test1();
+    test2();
+    test3();
+    test4();
+    test5();
+    test6();
+    test7();
 
-    test->add( BOOST_TEST_CASE( & test1) );
-    test->add( BOOST_TEST_CASE( & test2) );
-    test->add( BOOST_TEST_CASE( & test3) );
-    test->add( BOOST_TEST_CASE( & test4) );
-    test->add( BOOST_TEST_CASE( & test5) );
-    test->add( BOOST_TEST_CASE( & test6) );
-    test->add( BOOST_TEST_CASE( & test7) );
-
-    return test;
+    return boost::report_errors();
 }

--- a/test/test_callcc.cpp
+++ b/test/test_callcc.cpp
@@ -21,8 +21,8 @@
 
 #include <boost/array.hpp>
 #include <boost/assert.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/test/unit_test.hpp>
 #include <boost/utility.hpp>
 #include <boost/variant.hpp>
 
@@ -32,6 +32,9 @@
 #ifdef BOOST_WINDOWS
 #include <windows.h>
 #endif
+
+#define BOOST_CHECK(x) BOOST_TEST(x)
+#define BOOST_CHECK_EQUAL(a, b) BOOST_TEST_EQ(a, b)
 
 #if defined(BOOST_MSVC)
 # pragma warning(push)
@@ -485,30 +488,27 @@ void test_badcatch() {
 #endif
 }
 
-boost::unit_test::test_suite * init_unit_test_suite( int, char* [])
+int main()
 {
-    boost::unit_test::test_suite * test =
-        BOOST_TEST_SUITE("Boost.Context: callcc test suite");
-
-    test->add( BOOST_TEST_CASE( & test_move) );
-    test->add( BOOST_TEST_CASE( & test_bind) );
-    test->add( BOOST_TEST_CASE( & test_exception) );
-    test->add( BOOST_TEST_CASE( & test_fp) );
-    test->add( BOOST_TEST_CASE( & test_stacked) );
-    test->add( BOOST_TEST_CASE( & test_prealloc) );
-    test->add( BOOST_TEST_CASE( & test_ontop) );
-    test->add( BOOST_TEST_CASE( & test_ontop_exception) );
-    test->add( BOOST_TEST_CASE( & test_termination1) );
-    test->add( BOOST_TEST_CASE( & test_termination2) );
-    test->add( BOOST_TEST_CASE( & test_sscanf) );
-    test->add( BOOST_TEST_CASE( & test_snprintf) );
+    test_move();
+    test_bind();
+    test_exception();
+    test_fp();
+    test_stacked();
+    test_prealloc();
+    test_ontop();
+    test_ontop_exception();
+    test_termination1();
+    test_termination2();
+    test_sscanf();
+    test_snprintf();
 #ifdef BOOST_WINDOWS
-    test->add( BOOST_TEST_CASE( & test_bug12215) );
+    test_bug12215();
 #endif
-    test->add( BOOST_TEST_CASE( & test_goodcatch) );
-    test->add( BOOST_TEST_CASE( & test_badcatch) );
+    test_goodcatch();
+    test_badcatch();
 
-    return test;
+    return boost::report_errors();
 }
 
 #if defined(BOOST_MSVC)

--- a/test/test_fcontext.cpp
+++ b/test/test_fcontext.cpp
@@ -17,11 +17,14 @@
 
 #include <boost/array.hpp>
 #include <boost/assert.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/utility.hpp>
 
 #include <boost/context/detail/config.hpp>
 #include <boost/context/detail/fcontext.hpp>
+
+#define BOOST_CHECK(x) BOOST_TEST(x)
+#define BOOST_CHECK_EQUAL(a, b) BOOST_TEST_EQ(a, b)
 
 template< std::size_t Max, std::size_t Default, std::size_t Min >
 class simple_stack_allocator
@@ -332,21 +335,20 @@ void test_snprintf() {
 	alloc.deallocate( sp, stack_allocator::default_stacksize() );
 }
 
-boost::unit_test::test_suite * init_unit_test_suite( int, char* []) {
-    boost::unit_test::test_suite * test =
-        BOOST_TEST_SUITE("Boost.Context: fcontext test suite");
-    test->add( BOOST_TEST_CASE( & test_setup) );
-    test->add( BOOST_TEST_CASE( & test_start) );
-    test->add( BOOST_TEST_CASE( & test_jump) );
-    test->add( BOOST_TEST_CASE( & test_result) );
-    test->add( BOOST_TEST_CASE( & test_arg) );
-    test->add( BOOST_TEST_CASE( & test_transfer) );
-    test->add( BOOST_TEST_CASE( & test_exception) );
-    test->add( BOOST_TEST_CASE( & test_fp) );
-    test->add( BOOST_TEST_CASE( & test_stacked) );
-    test->add( BOOST_TEST_CASE( & test_ontop) );
-    test->add( BOOST_TEST_CASE( & test_sscanf) );
-    test->add( BOOST_TEST_CASE( & test_snprintf) );
+int main()
+{
+    test_setup();
+    test_start();
+    test_jump();
+    test_result();
+    test_arg();
+    test_transfer();
+    test_exception();
+    test_fp();
+    test_stacked();
+    test_ontop();
+    test_sscanf();
+    test_snprintf();
 
-    return test;
+    return boost::report_errors();
 }

--- a/test/test_fiber.cpp
+++ b/test/test_fiber.cpp
@@ -21,8 +21,8 @@
 
 #include <boost/array.hpp>
 #include <boost/assert.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/test/unit_test.hpp>
 #include <boost/utility.hpp>
 #include <boost/variant.hpp>
 
@@ -32,6 +32,9 @@
 #ifdef BOOST_WINDOWS
 #include <windows.h>
 #endif
+
+#define BOOST_CHECK(x) BOOST_TEST(x)
+#define BOOST_CHECK_EQUAL(a, b) BOOST_TEST_EQ(a, b)
 
 #if defined(BOOST_MSVC)
 # pragma warning(push)
@@ -507,30 +510,27 @@ void test_badcatch() {
 #endif
 }
 
-boost::unit_test::test_suite * init_unit_test_suite( int, char* [])
+int main()
 {
-    boost::unit_test::test_suite * test =
-        BOOST_TEST_SUITE("Boost.Context: fiber test suite");
-
-    test->add( BOOST_TEST_CASE( & test_move) );
-    test->add( BOOST_TEST_CASE( & test_bind) );
-    test->add( BOOST_TEST_CASE( & test_exception) );
-    test->add( BOOST_TEST_CASE( & test_fp) );
-    test->add( BOOST_TEST_CASE( & test_stacked) );
-    test->add( BOOST_TEST_CASE( & test_prealloc) );
-    test->add( BOOST_TEST_CASE( & test_ontop) );
-    test->add( BOOST_TEST_CASE( & test_ontop_exception) );
-    test->add( BOOST_TEST_CASE( & test_termination1) );
-    test->add( BOOST_TEST_CASE( & test_termination2) );
-    test->add( BOOST_TEST_CASE( & test_sscanf) );
-    test->add( BOOST_TEST_CASE( & test_snprintf) );
+    test_move();
+    test_bind();
+    test_exception();
+    test_fp();
+    test_stacked();
+    test_prealloc();
+    test_ontop();
+    test_ontop_exception();
+    test_termination1();
+    test_termination2();
+    test_sscanf();
+    test_snprintf();
 #ifdef BOOST_WINDOWS
-    test->add( BOOST_TEST_CASE( & test_bug12215) );
+    test_bug12215();
 #endif
-    test->add( BOOST_TEST_CASE( & test_goodcatch) );
-    test->add( BOOST_TEST_CASE( & test_badcatch) );
+    test_goodcatch();
+    test_badcatch();
 
-    return test;
+    return boost::report_errors();
 }
 
 #if defined(BOOST_MSVC)

--- a/test/test_invoke.cpp
+++ b/test/test_invoke.cpp
@@ -14,11 +14,13 @@
 
 #include <boost/config.hpp>
 #include <boost/assert.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #if defined(BOOST_NO_CXX17_STD_INVOKE)
 #include <boost/context/detail/invoke.hpp>
 #include <boost/context/detail/config.hpp>
+
+#define BOOST_CHECK_EQUAL(a, b) BOOST_TEST_EQ(a, b)
 
 namespace ctx = boost::context;
 
@@ -220,23 +222,20 @@ void test8() {
 void dummy() {}
 #endif
 
-boost::unit_test::test_suite * init_unit_test_suite( int, char* [])
+int main()
 {
-    boost::unit_test::test_suite * test =
-        BOOST_TEST_SUITE("Boost.Context: invoke test suite");
-
 #if defined(BOOST_NO_CXX17_STD_INVOKE)
-    test->add( BOOST_TEST_CASE( & test1) );
-    test->add( BOOST_TEST_CASE( & test2) );
-    test->add( BOOST_TEST_CASE( & test3) );
-    test->add( BOOST_TEST_CASE( & test4) );
-    test->add( BOOST_TEST_CASE( & test5) );
-    test->add( BOOST_TEST_CASE( & test6) );
-    test->add( BOOST_TEST_CASE( & test7) );
-    test->add( BOOST_TEST_CASE( & test8) );
+    test1();
+    test2();
+    test3();
+    test4();
+    test5();
+    test6();
+    test7();
+    test8();
 #else
-    test->add( BOOST_TEST_CASE( & dummy) );
+    dummy();
 #endif
 
-    return test;
+    return boost::report_errors();
 }


### PR DESCRIPTION
Run tests on most of supported platforms via QEMU. There seems to be no distro that supports powerpc, debian jessie packages for powerpc are no longer available.

Some changes I had to make:
- Run segmented stack tests only when compiler has `-fsplit-stack` and targeted libstdc++ (adds Clang, limits on unsupported arches and stdlibs).
- Switch to lightweight tester from Boost.Test. It was failing mingw for some reason, and this also speed up qemu runners at least x2 (ppc64el 28mins vs 11mins).
