### PR TITLE
Darwin make_ppc32: fix addi in l1

### DIFF
--- a/src/asm/make_ppc32_sysv_macho_gas.S
+++ b/src/asm/make_ppc32_sysv_macho_gas.S
@@ -106,12 +106,12 @@ _make_fcontext:
     ; load LR
     mflr  r0
     ; jump to label 1
-    bl  1f
-1:
+    bl  l1
+l1:
     ; load LR into R4
     mflr  r4
     ; compute abs address of label finish
-    addi  r4, r4, finish - 1b
+    addi  r4, r4, lo16((finish - .) + 4)
     ; restore LR
     mtlr  r0
     ; save address of finish as return-address for context-function


### PR DESCRIPTION
Minor but needed fix to Darwin ppc32 code: https://github.com/boostorg/context/pull/204#issuecomment-1270061890

Builds fine on 10.5.8, 10.6 PPC (10A190) and 10.6.8 Rosetta.
Functionality: just built `folly` (which depends on context/coroutine) on 10.5.8 ppc with it with a bunch of dependents, so apparently all good.

@olk Hopefully we are done at this, and Darwin PPC will finally work. Once merged here, I will bring it to Macports.