### PR TITLE
Make sure the i386 sysv stack is aligned

### DIFF
--- a/src/asm/make_i386_sysv_elf_gas.S
+++ b/src/asm/make_i386_sysv_elf_gas.S
@@ -40,8 +40,8 @@ make_fcontext:
     /* shift address in EAX to lower 16 byte boundary */
     andl  $-16, %eax
 
-    /* reserve space for context-data on context-stack */
-    leal  -0x2c(%eax), %eax
+    /* reserve space for context-data on context-stack, and align the stack */
+    leal  -0x30(%eax), %eax
 
     /* third arg of make_fcontext() == address of context-function */
     /* stored in EBX */

--- a/src/asm/make_i386_sysv_macho_gas.S
+++ b/src/asm/make_i386_sysv_macho_gas.S
@@ -38,8 +38,8 @@ _make_fcontext:
     /* shift address in EAX to lower 16 byte boundary */
     andl  $-16, %eax
 
-    /* reserve space for context-data on context-stack */
-    leal  -0x2c(%eax), %eax
+    /* reserve space for context-data on context-stack, and align the stack */
+    leal  -0x30(%eax), %eax
 
     /* third arg of make_fcontext() == address of context-function */
     /* stored in EBX */


### PR DESCRIPTION
SysV ABI requires a stack alignment of 16 bytes. Currently, for i386 with SysV ABI, the trampoline function is entered with an unaligned stack. This causes problems for the context-function that is jumped to as its stack is also unaligned. This causes a crash for our use-case because the context function contains an SSE instruction which reads from the stack. The SSE instruction requires the correct alignment. Fix it by changing the 0x2c offset to 0x30, such that the stack remains aligned.

Related issue in this repo: #210 

For reference:
https://github.com/php/php-src/pull/10407#issuecomment-1404180877 and https://github.com/php/php-src/issues/10398