### PR TITLE
Store entry point arguments in fibre's own stack (s390x)

### DIFF
--- a/src/asm/jump_s390x_sysv_elf_gas.S
+++ b/src/asm/jump_s390x_sysv_elf_gas.S
@@ -131,11 +131,11 @@ jump_fcontext:
 	ltg	%r2,GR_OFFSET(%r15)
 	jnz	use_return_slot
 
-	/* We restore a make_fcontext context.  Use the function
-	   argument slot in the context we just saved and allocate the
-	   register save area for the target function.  */
-	la	%r2,ARG_OFFSET(%r1)
-	aghi	%r15,-REG_SAVE_AREA_SIZE
+	/* We're restoring a context created by make_fcontext.
+	   Use the function argument slot in the current context
+	   and make sure it isn't deallocated. */
+	la	%r2,ARG_OFFSET(%r15)
+	aghi	%r15,-CONTEXT_SIZE
 
 use_return_slot:
 	/* Save the two fields in transfer_t.  When calling a

--- a/src/asm/make_s390x_sysv_elf_gas.S
+++ b/src/asm/make_s390x_sysv_elf_gas.S
@@ -71,7 +71,7 @@ r4 - The address of the context function
 
 make_fcontext:
 	.machine "z10"
-	/* Align the stack to an 8 byte boundary.  */
+	/* Align the stack to an 16 byte boundary.  */
 	nill    %r2,0xfff0
 
 	/* Allocate stack space for the context.  */

--- a/src/asm/ontop_s390x_sysv_elf_gas.S
+++ b/src/asm/ontop_s390x_sysv_elf_gas.S
@@ -82,6 +82,7 @@ created via make_fcontext.
 */
 
 ontop_fcontext:
+	.machine "z10"
 	/* Reserve stack space to store the current context.  */
 	aghi	%r15,-CONTEXT_SIZE
 


### PR DESCRIPTION
In the current implementation fibres spawned by other fibres or threads would have the argument of their entry point (`void fiber_entry( transfer_t t)`) be allocated on the stack of their parent, which would then cause segmentation fault if the former outlived the latter.

The x86-64 implementation (`x86_64_sysv_elf` is the combination I tested) supports this use-case, so this change means to achieve feature parity for the s390x implementation in this regard by storing the aforementioned argument in the fibre's own stack.