### PR TITLE
Improve ABI conformance of s390x fcontext

### DIFF
--- a/src/asm/jump_s390x_sysv_elf_gas.S
+++ b/src/asm/jump_s390x_sysv_elf_gas.S
@@ -49,11 +49,12 @@
 .type	jump_fcontext, @function
 
 #define ARG_OFFSET         0
-#define GR_OFFSET	   16
-#define FP_OFFSET	   96
-#define FPC_OFFSET	   160
-#define PC_OFFSET	   168
-#define CONTEXT_SIZE	   176
+#define GR_OFFSET          16
+#define R14_OFFSET         88
+#define FP_OFFSET          96
+#define FPC_OFFSET         160
+#define PC_OFFSET          168
+#define CONTEXT_SIZE       176
 
 #define REG_SAVE_AREA_SIZE 160
 
@@ -132,10 +133,13 @@ jump_fcontext:
 	jnz	use_return_slot
 
 	/* We're restoring a context created by make_fcontext.
-	   Use the function argument slot in the current context
-	   and make sure it isn't deallocated. */
-	la	%r2,ARG_OFFSET(%r15)
-	aghi	%r15,-CONTEXT_SIZE
+	   This is going to be the argument of the entry point
+	   of the fiber. We're placing it on top of the ABI
+	   defined register save area of the fiber's own stack. */
+	la	%r2,REG_SAVE_AREA_SIZE(%r15)
+
+	/* REG_SAVE_AREA_SIZE + sizeof(transfer_t) */
+	aghi	%r15,-(REG_SAVE_AREA_SIZE+16)
 
 use_return_slot:
 	/* Save the two fields in transfer_t.  When calling a

--- a/src/asm/make_s390x_sysv_elf_gas.S
+++ b/src/asm/make_s390x_sysv_elf_gas.S
@@ -49,12 +49,12 @@
 .type	make_fcontext, @function
 
 #define ARG_OFFSET         0
-#define GR_OFFSET	   16
-#define R14_OFFSET	   88
-#define FP_OFFSET	   96
-#define FPC_OFFSET	   160
-#define PC_OFFSET	   168
-#define CONTEXT_SIZE	   176
+#define GR_OFFSET          16
+#define R14_OFFSET         88
+#define FP_OFFSET          96
+#define FPC_OFFSET         160
+#define PC_OFFSET          168
+#define CONTEXT_SIZE       176
 
 /*
 
@@ -71,8 +71,8 @@ r4 - The address of the context function
 
 make_fcontext:
 	.machine "z10"
-	/* Align the stack to an 16 byte boundary.  */
-	nill    %r2,0xfff0
+	/* Align the stack to an 8 byte boundary.  */
+	nill    %r2,0xfff8
 
 	/* Allocate stack space for the context.  */
 	aghi	%r2,-CONTEXT_SIZE

--- a/src/asm/ontop_s390x_sysv_elf_gas.S
+++ b/src/asm/ontop_s390x_sysv_elf_gas.S
@@ -49,13 +49,12 @@
 .type   ontop_fcontext, @function
 
 #define ARG_OFFSET         0
-#define GR_OFFSET	   16
-#define R14_OFFSET	   88
-#define FP_OFFSET	   96
-#define FPC_OFFSET	   160
-#define PC_OFFSET	   168
-#define CONTEXT_SIZE	   176
-
+#define GR_OFFSET          16
+#define R14_OFFSET         88
+#define FP_OFFSET          96
+#define FPC_OFFSET         160
+#define PC_OFFSET          168
+#define CONTEXT_SIZE       176
 
 /*
 
@@ -82,7 +81,6 @@ created via make_fcontext.
 */
 
 ontop_fcontext:
-	.machine "z10"
 	/* Reserve stack space to store the current context.  */
 	aghi	%r15,-CONTEXT_SIZE
 


### PR DESCRIPTION
I implemented review comments by @Andreas-Krebbel from #224. I ran the tests using `b2` (`../../../b2 -a`) and everything seems to be passing.