### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
             buildtype: "boost"
             packages: ""
             packages_to_remove: ""
-            os: "ubuntu-20.04"
             container: "ubuntu:16.04"
             cxx: "g++"
             sources: ""
@@ -34,7 +33,6 @@ jobs:
             buildtype: "boost"
             packages: "g++-5"
             packages_to_remove: ""
-            os: "ubuntu-20.04"
             container: "ubuntu:16.04"
             cxx: "g++-5"
             sources: ""
@@ -47,7 +45,6 @@ jobs:
             buildtype: "boost"
             packages: "g++-6"
             packages_to_remove: ""
-            os: "ubuntu-20.04"
             container: "ubuntu:16.04"
             cxx: "g++-6"
             sources: ""
@@ -60,7 +57,6 @@ jobs:
             buildtype: "boost"
             packages: "g++-7"
             packages_to_remove: ""
-            os: "ubuntu-20.04"
             container: "ubuntu:16.04"
             cxx: "g++-7"
             sources: ""
@@ -71,9 +67,9 @@ jobs:
             cxxstd: "11,14,17"
           - name: "TOOLSET=clang COMPILER=clang++ CXXSTD=11 Job 4"
             buildtype: "boost"
-            packages: ""
+            packages: "clang"
             packages_to_remove: ""
-            os: "ubuntu-18.04"
+            container: "ubuntu:18.04"
             cxx: "clang++"
             sources: ""
             llvm_os: ""
@@ -85,7 +81,6 @@ jobs:
             buildtype: "boost"
             packages: "clang-4.0 libstdc++-6-dev"
             packages_to_remove: ""
-            os: "ubuntu-20.04"
             container: "ubuntu:16.04"
             cxx: "clang++-4.0"
             sources: ""
@@ -98,7 +93,6 @@ jobs:
             buildtype: "boost"
             packages: "clang-5.0 libstdc++-7-dev"
             packages_to_remove: ""
-            os: "ubuntu-20.04"
             container: "ubuntu:16.04"
             cxx: "clang++-5.0"
             sources: ""
@@ -108,7 +102,7 @@ jobs:
             compiler: "clang++-5.0"
             cxxstd: "11,14,1z"
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     container: ${{ matrix.container }}
 
     steps:
@@ -121,10 +115,6 @@ jobs:
             apt-get -o Acquire::Retries=3 update && DEBIAN_FRONTEND=noninteractive apt-get -y install tzdata && apt-get -o Acquire::Retries=3 install -y sudo software-properties-common wget curl apt-transport-https make apt-file sudo unzip libssl-dev build-essential autotools-dev autoconf automake g++ libc++-helpers python ruby cpio gcc-multilib g++-multilib pkgconf python3 ccache libpython-dev
             sudo apt-add-repository ppa:git-core/ppa
             sudo apt-get -o Acquire::Retries=3 update && apt-get -o Acquire::Retries=3 -y install git
-            python_version=$(python3 -c 'import sys; print("{0.major}.{0.minor}".format(sys.version_info))')
-            sudo wget https://bootstrap.pypa.io/pip/$python_version/get-pip.py
-            sudo python3 get-pip.py
-            sudo /usr/local/bin/pip install cmake
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/multi.yml
+++ b/.github/workflows/multi.yml
@@ -14,23 +14,25 @@ on:
 
 jobs:
   emulated:
-    name: ${{ matrix.arch || 'native' }} ${{ matrix.os || matrix.distro || 'bullseye' }} ${{ matrix.toolset }}
+    name: ${{ matrix.container }} ${{ matrix.platform }} ${{ matrix.toolset }}
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - amd64
-          - arm64
-          - armel
-          - armhf
-          - i386
-          - mipsel
-          - mips64el
-          - ppc64el
-          - s390x
+        container: [ 'debian' ]
+        platform:
+          - linux/386
+          - linux/amd64
+          - linux/arm/v5
+          - linux/arm/v7
+          - linux/arm64/v8
+          - linux/mips64le
+          - linux/ppc64le
+          - linux/s390x
         include:
-          - { arch: mips, distro: buster }
+          - { container: 'debian:experimental', platform: linux/riscv64 }
+          - { container: 'lpenz/debian-buster-mipsel', platform: linux/mipsel }
+          - { container: 'lpenz/debian-buster-mips', platform: linux/mips }
 
     steps:
       - name: Checkout Boost super-repo
@@ -48,7 +50,7 @@ jobs:
           tools/boostdep
 
       - name: Checkout the commit
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libs/context
 
@@ -56,21 +58,21 @@ jobs:
         run: python tools/boostdep/depinst/depinst.py --git_args "--jobs 10" context
 
       - name: "Setup QEMU and Docker"
-        if: matrix.arch
         run: |
           set -eu
           sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get -o Acquire::Retries=3 -y install qemu-user-static
-          docker pull multiarch/debian-debootstrap:${{ matrix.arch }}-${{ matrix.distro || 'bullseye' }}
 
-      - name: "Building and testing on ${{ matrix.arch }}"
+      - name: "Building and testing on ${{ matrix.container }} ${{ matrix.platform }}"
         uses: addnab/docker-run-action@v3
-        if: matrix.arch
         with:
-          image: multiarch/debian-debootstrap:${{ matrix.arch }}-${{ matrix.distro || 'bullseye' }}
-          options: -v ${{ github.workspace }}:/boost-root -w /boost-root
+          image: ${{ matrix.container }}
+          options: -v ${{ github.workspace }}:/boost-root -w /boost-root ${{ matrix.platform && format('--platform {0}', matrix.platform) || '' }}
           run: |
             set -eu
+            echo "::group::Switch to archive repository"
+              ${{ contains(matrix.container, 'buster') }} && sed -i 's/deb.debian/archive.debian/' /etc/apt/sources.list && cat /etc/apt/sources.list
+            echo "::endgroup::"
             echo "::group::Install GCC"
               apt-get -o Acquire::Retries=3 update
               apt-get -o Acquire::Retries=3 -yq --no-install-suggests --no-install-recommends install g++
@@ -119,7 +121,7 @@ jobs:
           tools/boostdep
 
       - name: Checkout the commit
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libs/context
 


### PR DESCRIPTION
* GHA ubuntu-18.04 image is no longer available -> switch to docker container.
* arm64 multiarch docker container contains outdated sign keys because their deployment CI is broken -> switch to official debian docker containers where possible.