### PR TITLE
Mark fcontext asm functions as hidden visibility

### DIFF
--- a/src/asm/jump_arm64_aapcs_elf_gas.S
+++ b/src/asm/jump_arm64_aapcs_elf_gas.S
@@ -55,6 +55,7 @@
 .text
 .align  2
 .global jump_fcontext
+.hidden jump_fcontext
 .type   jump_fcontext, %function
 jump_fcontext:
     # prepare stack for GP + FPU

--- a/src/asm/jump_arm64_aapcs_macho_gas.S
+++ b/src/asm/jump_arm64_aapcs_macho_gas.S
@@ -52,6 +52,7 @@
  *******************************************************/
 
 .text
+.private_extern _jump_fcontext
 .globl _jump_fcontext
 .balign 16
 _jump_fcontext:

--- a/src/asm/jump_arm_aapcs_elf_gas.S
+++ b/src/asm/jump_arm_aapcs_elf_gas.S
@@ -41,6 +41,7 @@
 .file "jump_arm_aapcs_elf_gas.S"
 .text
 .globl jump_fcontext
+.hidden jump_fcontext
 .align 2
 .type jump_fcontext,%function
 .syntax unified

--- a/src/asm/jump_arm_aapcs_macho_gas.S
+++ b/src/asm/jump_arm_aapcs_macho_gas.S
@@ -39,6 +39,7 @@
  *******************************************************/
 
 .text
+.private_extern _jump_fcontext
 .globl _jump_fcontext
 .align 2
 _jump_fcontext:

--- a/src/asm/jump_i386_sysv_elf_gas.S
+++ b/src/asm/jump_i386_sysv_elf_gas.S
@@ -31,6 +31,7 @@
 .file "jump_i386_sysv_elf_gas.S"
 .text
 .globl jump_fcontext
+.hidden jump_fcontext
 .align 2
 .type jump_fcontext,@function
 jump_fcontext:

--- a/src/asm/jump_i386_sysv_macho_gas.S
+++ b/src/asm/jump_i386_sysv_macho_gas.S
@@ -25,6 +25,7 @@
  ****************************************************************************************/
 
 .text
+.private_extern _jump_fcontext
 .globl _jump_fcontext
 .align 2
 _jump_fcontext:

--- a/src/asm/jump_loongarch64_sysv_elf_gas.S
+++ b/src/asm/jump_loongarch64_sysv_elf_gas.S
@@ -41,6 +41,7 @@
 .file "jump_loongarch64_sysv_elf_gas.S"
 .text
 .globl jump_fcontext
+.hidden jump_fcontext
 .align 2
 .type jump_fcontext,@function
 jump_fcontext:

--- a/src/asm/jump_mips32_o32_elf_gas.S
+++ b/src/asm/jump_mips32_o32_elf_gas.S
@@ -41,6 +41,7 @@
 .file "jump_mips32_o32_elf_gas.S"
 .text
 .globl jump_fcontext
+.hidden jump_fcontext
 .align 2
 .type jump_fcontext,@function
 .ent jump_fcontext

--- a/src/asm/jump_mips64_n64_elf_gas.S
+++ b/src/asm/jump_mips64_n64_elf_gas.S
@@ -48,6 +48,7 @@
 .file "jump_mips64_n64_elf_gas.S"
 .text
 .globl jump_fcontext
+.hidden jump_fcontext
 .align 3
 .type jump_fcontext,@function
 .ent jump_fcontext

--- a/src/asm/jump_ppc32_sysv_elf_gas.S
+++ b/src/asm/jump_ppc32_sysv_elf_gas.S
@@ -53,6 +53,7 @@
 .file "jump_ppc32_sysv_elf_gas.S"
 .text
 .globl jump_fcontext
+.hidden jump_fcontext
 .align 2
 .type jump_fcontext,@function
 jump_fcontext:

--- a/src/asm/jump_ppc32_sysv_macho_gas.S
+++ b/src/asm/jump_ppc32_sysv_macho_gas.S
@@ -74,6 +74,7 @@
  *******************************************************/
 
 .text
+.private_extern _jump_fcontext
 .globl _jump_fcontext
 .align 2
 _jump_fcontext:

--- a/src/asm/jump_ppc64_sysv_elf_gas.S
+++ b/src/asm/jump_ppc64_sysv_elf_gas.S
@@ -68,6 +68,7 @@
 
 .file "jump_ppc64_sysv_elf_gas.S"
 .globl jump_fcontext
+.hidden jump_fcontext
 #if _CALL_ELF == 2
 	.text
 	.align 2

--- a/src/asm/jump_ppc64_sysv_macho_gas.S
+++ b/src/asm/jump_ppc64_sysv_macho_gas.S
@@ -68,6 +68,7 @@
 
 .text
 .align 2
+.private_extern _jump_fcontext
 .globl _jump_fcontext
 
 _jump_fcontext:

--- a/src/asm/jump_riscv64_sysv_elf_gas.S
+++ b/src/asm/jump_riscv64_sysv_elf_gas.S
@@ -61,6 +61,7 @@
 .text
 .align  1
 .global jump_fcontext
+.hidden jump_fcontext
 .type   jump_fcontext, %function
 jump_fcontext:
     # prepare stack for GP + FPU

--- a/src/asm/jump_s390x_sysv_elf_gas.S
+++ b/src/asm/jump_s390x_sysv_elf_gas.S
@@ -46,6 +46,7 @@
 .text
 .align	8
 .global	jump_fcontext
+.hidden jump_fcontext
 .type	jump_fcontext, @function
 
 #define ARG_OFFSET         0

--- a/src/asm/jump_x86_64_sysv_elf_gas.S
+++ b/src/asm/jump_x86_64_sysv_elf_gas.S
@@ -44,6 +44,7 @@
 .file "jump_x86_64_sysv_elf_gas.S"
 .text
 .globl jump_fcontext
+.hidden jump_fcontext
 .type jump_fcontext,@function
 .align 16
 jump_fcontext:

--- a/src/asm/jump_x86_64_sysv_macho_gas.S
+++ b/src/asm/jump_x86_64_sysv_macho_gas.S
@@ -25,6 +25,7 @@
  ****************************************************************************************/
 
 .text
+.private_extern _jump_fcontext
 .globl _jump_fcontext
 .align 8
 _jump_fcontext:

--- a/src/asm/make_arm64_aapcs_elf_gas.S
+++ b/src/asm/make_arm64_aapcs_elf_gas.S
@@ -55,6 +55,7 @@
 .text
 .align  2
 .global make_fcontext
+.hidden make_fcontext
 .type   make_fcontext, %function
 make_fcontext:
     # shift address in x0 (allocated stack) to lower 16 byte boundary

--- a/src/asm/make_arm64_aapcs_macho_gas.S
+++ b/src/asm/make_arm64_aapcs_macho_gas.S
@@ -52,6 +52,7 @@
  *******************************************************/
 
 .text
+.private_extern _make_fcontext
 .globl _make_fcontext
 .balign 16
 

--- a/src/asm/make_arm_aapcs_elf_gas.S
+++ b/src/asm/make_arm_aapcs_elf_gas.S
@@ -41,6 +41,7 @@
 .file "make_arm_aapcs_elf_gas.S"
 .text
 .globl make_fcontext
+.hidden make_fcontext
 .align 2
 .type make_fcontext,%function
 .syntax unified

--- a/src/asm/make_arm_aapcs_macho_gas.S
+++ b/src/asm/make_arm_aapcs_macho_gas.S
@@ -39,6 +39,7 @@
  *******************************************************/
 
 .text
+.private_extern _make_fcontext
 .globl _make_fcontext
 .align 2
 _make_fcontext:

--- a/src/asm/make_i386_sysv_elf_gas.S
+++ b/src/asm/make_i386_sysv_elf_gas.S
@@ -31,6 +31,7 @@
 .file "make_i386_sysv_elf_gas.S"
 .text
 .globl make_fcontext
+.hidden make_fcontext
 .align 2
 .type make_fcontext,@function
 make_fcontext:

--- a/src/asm/make_i386_sysv_macho_gas.S
+++ b/src/asm/make_i386_sysv_macho_gas.S
@@ -25,6 +25,7 @@
  ****************************************************************************************/
 
 .text
+.private_extern _make_fcontext
 .globl _make_fcontext
 .align 2
 _make_fcontext:

--- a/src/asm/make_loongarch64_sysv_elf_gas.S
+++ b/src/asm/make_loongarch64_sysv_elf_gas.S
@@ -41,6 +41,7 @@
 .file "make_loongarch64_sysv_elf_gas.S"
 .text
 .globl make_fcontext
+.hidden make_fcontext
 .align 2
 .type make_fcontext,@function
 make_fcontext:

--- a/src/asm/make_mips32_o32_elf_gas.S
+++ b/src/asm/make_mips32_o32_elf_gas.S
@@ -41,6 +41,7 @@
 .file "make_mips32_o32_elf_gas.S"
 .text
 .globl make_fcontext
+.hidden make_fcontext
 .align 2
 .type make_fcontext,@function
 .ent make_fcontext

--- a/src/asm/make_mips64_n64_elf_gas.S
+++ b/src/asm/make_mips64_n64_elf_gas.S
@@ -48,6 +48,7 @@
 .file "make_mips64_n64_elf_gas.S"
 .text
 .globl make_fcontext
+.hidden make_fcontext
 .align 3
 .type make_fcontext,@function
 .ent make_fcontext

--- a/src/asm/make_ppc32_sysv_elf_gas.S
+++ b/src/asm/make_ppc32_sysv_elf_gas.S
@@ -53,6 +53,7 @@
 .file "make_ppc32_sysv_elf_gas.S"
 .text
 .globl make_fcontext
+.hidden make_fcontext
 .align 2
 .type make_fcontext,@function
 make_fcontext:

--- a/src/asm/make_ppc32_sysv_macho_gas.S
+++ b/src/asm/make_ppc32_sysv_macho_gas.S
@@ -74,6 +74,7 @@
  *******************************************************/
 
 .text
+.private_extern _make_fcontext
 .globl _make_fcontext
 .align 2
 _make_fcontext:

--- a/src/asm/make_ppc64_sysv_elf_gas.S
+++ b/src/asm/make_ppc64_sysv_elf_gas.S
@@ -68,6 +68,7 @@
 
 .file "make_ppc64_sysv_elf_gas.S"
 .globl make_fcontext
+.hidden make_fcontext
 #if _CALL_ELF == 2
 	.text
 	.align 2

--- a/src/asm/make_ppc64_sysv_macho_gas.S
+++ b/src/asm/make_ppc64_sysv_macho_gas.S
@@ -67,6 +67,7 @@
  *******************************************************/
 
 .text
+.private_extern _make_fcontext
 .globl _make_fcontext
 _make_fcontext:
     ; save return address into R6

--- a/src/asm/make_riscv64_sysv_elf_gas.S
+++ b/src/asm/make_riscv64_sysv_elf_gas.S
@@ -61,6 +61,7 @@
 .text
 .align  1
 .global make_fcontext
+.hidden make_fcontext
 .type   make_fcontext, %function
 make_fcontext:
     # shift address in a0 (allocated stack) to lower 16 byte boundary

--- a/src/asm/make_s390x_sysv_elf_gas.S
+++ b/src/asm/make_s390x_sysv_elf_gas.S
@@ -46,6 +46,7 @@
 .text
 .align	8
 .global	make_fcontext
+.hidden make_fcontext
 .type	make_fcontext, @function
 
 #define ARG_OFFSET         0

--- a/src/asm/make_x86_64_sysv_elf_gas.S
+++ b/src/asm/make_x86_64_sysv_elf_gas.S
@@ -44,6 +44,7 @@
 .file "make_x86_64_sysv_elf_gas.S"
 .text
 .globl make_fcontext
+.hidden make_fcontext
 .type make_fcontext,@function
 .align 16
 make_fcontext:

--- a/src/asm/make_x86_64_sysv_macho_gas.S
+++ b/src/asm/make_x86_64_sysv_macho_gas.S
@@ -25,6 +25,7 @@
  ****************************************************************************************/
 
 .text
+.private_extern _make_fcontext
 .globl _make_fcontext
 .align 8
 _make_fcontext:

--- a/src/asm/ontop_arm64_aapcs_elf_gas.S
+++ b/src/asm/ontop_arm64_aapcs_elf_gas.S
@@ -55,6 +55,7 @@
 .text
 .align  2
 .global ontop_fcontext
+.hidden ontop_fcontext
 .type   ontop_fcontext, %function
 ontop_fcontext:
     # prepare stack for GP + FPU

--- a/src/asm/ontop_arm64_aapcs_macho_gas.S
+++ b/src/asm/ontop_arm64_aapcs_macho_gas.S
@@ -52,6 +52,7 @@
  *******************************************************/
 
 .text
+.private_extern _ontop_fcontext
 .global _ontop_fcontext
 .balign 16
 _ontop_fcontext:

--- a/src/asm/ontop_arm_aapcs_elf_gas.S
+++ b/src/asm/ontop_arm_aapcs_elf_gas.S
@@ -41,6 +41,7 @@
 .file "ontop_arm_aapcs_elf_gas.S"
 .text
 .globl ontop_fcontext
+.hidden ontop_fcontext
 .align 2
 .type ontop_fcontext,%function
 .syntax unified

--- a/src/asm/ontop_arm_aapcs_macho_gas.S
+++ b/src/asm/ontop_arm_aapcs_macho_gas.S
@@ -39,6 +39,7 @@
  *******************************************************/
 
 .text
+.private_extern _ontop_fcontext
 .globl _ontop_fcontext
 .align 2
 _ontop_fcontext:

--- a/src/asm/ontop_i386_sysv_elf_gas.S
+++ b/src/asm/ontop_i386_sysv_elf_gas.S
@@ -31,6 +31,7 @@
 .file "ontop_i386_sysv_elf_gas.S"
 .text
 .globl ontop_fcontext
+.hidden ontop_fcontext
 .align 2
 .type ontop_fcontext,@function
 ontop_fcontext:

--- a/src/asm/ontop_i386_sysv_macho_gas.S
+++ b/src/asm/ontop_i386_sysv_macho_gas.S
@@ -25,6 +25,7 @@
  ****************************************************************************************/
 
 .text
+.private_extern _ontop_fcontext
 .globl _ontop_fcontext
 .align 2
 _ontop_fcontext:

--- a/src/asm/ontop_loongarch64_sysv_elf_gas.S
+++ b/src/asm/ontop_loongarch64_sysv_elf_gas.S
@@ -41,6 +41,7 @@
 .file "ontop_loongarch64_sysv_elf_gas.S"
 .text
 .globl ontop_fcontext
+.hidden ontop_fcontext
 .align 2
 .type ontop_fcontext,@function
 ontop_fcontext:

--- a/src/asm/ontop_mips32_o32_elf_gas.S
+++ b/src/asm/ontop_mips32_o32_elf_gas.S
@@ -41,6 +41,7 @@
 .file "ontop_mips32_o32_elf_gas.S"
 .text
 .globl ontop_fcontext
+.hidden ontop_fcontext
 .align 2
 .type ontop_fcontext,@function
 .ent ontop_fcontext

--- a/src/asm/ontop_mips64_n64_elf_gas.S
+++ b/src/asm/ontop_mips64_n64_elf_gas.S
@@ -48,6 +48,7 @@
 .file "ontop_mips64_n64_elf_gas.S"
 .text
 .globl ontop_fcontext
+.hidden ontop_fcontext
 .align 3
 .type ontop_fcontext,@function
 .ent ontop_fcontext

--- a/src/asm/ontop_ppc32_sysv_elf_gas.S
+++ b/src/asm/ontop_ppc32_sysv_elf_gas.S
@@ -53,6 +53,7 @@
 .file "ontop_ppc32_sysv_elf_gas.S"
 .text
 .globl ontop_fcontext
+.hidden ontop_fcontext
 .align 2
 .type ontop_fcontext,@function
 ontop_fcontext:

--- a/src/asm/ontop_ppc32_sysv_macho_gas.S
+++ b/src/asm/ontop_ppc32_sysv_macho_gas.S
@@ -74,6 +74,7 @@
  *******************************************************/
 
 .text
+.private_extern _ontop_fcontext
 .globl _ontop_fcontext
 .align 2
 _ontop_fcontext:

--- a/src/asm/ontop_ppc64_sysv_elf_gas.S
+++ b/src/asm/ontop_ppc64_sysv_elf_gas.S
@@ -68,6 +68,7 @@
 
 .file "ontop_ppc64_sysv_elf_gas.S"
 .globl ontop_fcontext
+.hidden ontop_fcontext
 #if _CALL_ELF == 2
 	.text
 	.align 2

--- a/src/asm/ontop_ppc64_sysv_macho_gas.S
+++ b/src/asm/ontop_ppc64_sysv_macho_gas.S
@@ -68,6 +68,7 @@
 
 .text
 .align 2
+.private_extern _ontop_fcontext
 .globl _ontop_fcontext
 
 _ontop_fcontext:

--- a/src/asm/ontop_riscv64_sysv_elf_gas.S
+++ b/src/asm/ontop_riscv64_sysv_elf_gas.S
@@ -61,6 +61,7 @@
 .text
 .align  1
 .global ontop_fcontext
+.hidden ontop_fcontext
 .type   ontop_fcontext, %function
 ontop_fcontext:
     # prepare stack for GP + FPU

--- a/src/asm/ontop_s390x_sysv_elf_gas.S
+++ b/src/asm/ontop_s390x_sysv_elf_gas.S
@@ -46,6 +46,7 @@
 .text
 .align  8
 .global ontop_fcontext
+.hidden ontop_fcontext
 .type   ontop_fcontext, @function
 
 #define ARG_OFFSET         0

--- a/src/asm/ontop_x86_64_sysv_elf_gas.S
+++ b/src/asm/ontop_x86_64_sysv_elf_gas.S
@@ -40,6 +40,7 @@
 .file "ontop_x86_64_sysv_elf_gas.S"
 .text
 .globl ontop_fcontext
+.hidden ontop_fcontext
 .type ontop_fcontext,@function
 .align 16
 ontop_fcontext:

--- a/src/asm/ontop_x86_64_sysv_macho_gas.S
+++ b/src/asm/ontop_x86_64_sysv_macho_gas.S
@@ -25,6 +25,7 @@
  ****************************************************************************************/
 
 .text
+.private_extern _ontop_fcontext
 .globl _ontop_fcontext
 .align 8
 _ontop_fcontext:


### PR DESCRIPTION
These functions should not be exported as dynamic
symbols if a library uses boost.

Note: I have no idea which if any changes armasm, armclang or xcoff assembler targets would need. It is also very lightly tested, essentially only the arm64_aapcs_macho target at this point.
So maybe more of a bug report/discussion point at this stage.