### PR TITLE
Define assembler files for ARM64 + Windows + GCC combination

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -204,9 +204,9 @@ alias asm_sources
 
 # ARM64/AAPCS/PE
 alias asm_sources
-   : asm/make_arm64_aapcs_pe_armclang.asm
-     asm/jump_arm64_aapcs_pe_armclang.asm
-     asm/ontop_arm64_aapcs_pe_armclang.asm
+   : asm/make_arm64_aapcs_pe_armclang.S
+     asm/jump_arm64_aapcs_pe_armclang.S
+     asm/ontop_arm64_aapcs_pe_armclang.S
    : <abi>aapcs
      <address-model>64
      <architecture>arm

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -202,7 +202,6 @@ alias asm_sources
      <toolset>msvc
    ;
 
-# ARM64/AAPCS/PE
 alias asm_sources
    : asm/make_arm64_aapcs_pe_armclang.S
      asm/jump_arm64_aapcs_pe_armclang.S
@@ -214,7 +213,6 @@ alias asm_sources
      <toolset>clang
    ;
 
-# ARM64/AAPCS/PE
 alias asm_sources
    : asm/make_arm64_aapcs_pe_armclang.S
      asm/jump_arm64_aapcs_pe_armclang.S

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -214,6 +214,18 @@ alias asm_sources
      <toolset>clang
    ;
 
+# ARM64/AAPCS/PE
+alias asm_sources
+   : asm/make_arm64_aapcs_pe_armclang.S
+     asm/jump_arm64_aapcs_pe_armclang.S
+     asm/ontop_arm64_aapcs_pe_armclang.S
+   : <abi>aapcs
+     <address-model>64
+     <architecture>arm
+     <binary-format>pe
+     <toolset>gcc
+   ;
+
 # LOONGARCH64
 # LOONGARCH64/SYSV/ELF
 alias asm_sources


### PR DESCRIPTION
Adds a definition which assembler files should be used for ARM64 + Windows + GCC combination. (This is needed for a new target `aarch64-w64-mingw32` for MinGW which is being developed here: https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build)

It is enough to use the existing assembler for Clang on Arm64 (introduced here https://github.com/boostorg/context/pull/262) as they both use the GNU syntax.

Also the first commit fixes the assembler extensions for Clang.