### PR TITLE
move context-impl feature into a module

### DIFF
--- a/boost-context-features.jam
+++ b/boost-context-features.jam
@@ -58,3 +58,14 @@ feature.feature abi
    : propagated
    ;
 feature.set-default abi : [ default_abi ] ;
+
+feature.feature context-impl
+    : fcontext
+      ucontext
+      winfib
+    : propagated
+      composite
+    ;
+feature.set-default context-impl : fcontext ;
+feature.compose <context-impl>ucontext : <define>BOOST_USE_UCONTEXT ;
+feature.compose <context-impl>winfib : <define>BOOST_USE_WINFIB ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -14,7 +14,6 @@ import modules ;
 import os ;
 import toolset ;
 import config : requires ;
-import feature ;
 
 project
     : common-requirements <library>$(boost_dependencies)
@@ -47,18 +46,6 @@ project
       <variant>release:<define>BOOST_DISABLE_ASSERTS
     : source-location ../src
     ;
-
-
-feature.feature context-impl
-    : fcontext
-      ucontext
-      winfib
-    : propagated
-      composite
-    ;
-feature.set-default context-impl : fcontext ;
-feature.compose <context-impl>ucontext : <define>BOOST_USE_UCONTEXT ;
-feature.compose <context-impl>winfib : <define>BOOST_USE_WINFIB ;
 
 
 # ARM


### PR DESCRIPTION
This is now necessary to allow users to set it from the command line.