### PR TITLE
Fix ABI detection for empty 'os.platform'

### DIFF
--- a/boost-context-features.jam
+++ b/boost-context-features.jam
@@ -37,9 +37,14 @@ feature.set-default binary-format : [ default_binary_format ] ;
 local rule default_abi ( )
 {
     local tmp = sysv ;
+
+    # Avoid using "in" operator here: it returns true if its left
+    # part is empty, which happens e.g. with os.platform on
+    # some uncommon architectures.
     if [ os.name ] = "NT" { tmp = ms ; }
     else if [ os.name ] = "CYGWIN" { tmp = ms ; }
-    else if [ os.platform ] in "ARM" "ARM64" { tmp = aapcs ; }
+    else if [ os.platform ] = "ARM" { tmp = aapcs ; }
+    else if [ os.platform ] = "ARM64" { tmp = aapcs ; }
     else if [ os.platform ] = "MIPS32" { tmp = o32 ; }
     else if [ os.platform ] = "MIPS64" { tmp = n64 ; }
     return $(tmp) ;


### PR DESCRIPTION
`in` operator in bjam always returns true if its first argument has no elements[1]. This means that if `os.platform` is empty (not detected), the construction introduced in commit 9084161b8778c18ebce7514f886f0f22f9bff490 sets ABI to `aapcs` on all platforms where `os.platform` is empty, including, e.g. loongarch64, and breaks build there.

This commit refactors the condition to use '=' operator, to make sure that when `os.platform` is empty we get the default ABI value, and thus fixes build on loongarch64.

See also 819c2d6423b4e0f55c5f69e334bf81570e82f68f for similar fix that was somehow lost in refactorings. This time a comment is added near the condition in hope that future edits will not reintroduce the issue.

[1] https://www.boost.org/doc/libs/1_83_0/tools/build/doc/html/index.html#jam.language.flow_of_control

Fixes: 9084161b8778c18ebce7514f886f0f22f9bff490