### PR TITLE
Suppressed unused variable warning in fiber_fcontext.hpp

### DIFF
--- a/include/boost/context/fiber_fcontext.hpp
+++ b/include/boost/context/fiber_fcontext.hpp
@@ -387,6 +387,7 @@ public:
     fiber resume_with( Fn && fn) && {
         BOOST_ASSERT( nullptr != fctx_);
         detail::manage_exception_state exstate;
+        boost::ignore_unused(exstate);
         auto p = std::forward< Fn >( fn);
         return { detail::ontop_fcontext(
 #if defined(BOOST_NO_CXX14_STD_EXCHANGE)


### PR DESCRIPTION
This completes https://github.com/boostorg/context/pull/285