### PR TITLE
Fix `clang-cl` `MSVC` frontend received `GNU` flag on assembling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,20 +178,21 @@ if(BOOST_CONTEXT_IMPLEMENTATION STREQUAL "fcontext")
 
     set_property(SOURCE ${ASM_SOURCES} APPEND PROPERTY COMPILE_OPTIONS "/nologo")
 
-    if(MSVC AND NOT(MSVC_VERSION LESS 1936)) # Visual Studio 2022 version 17.6
+    if(MSVC AND NOT(MSVC_VERSION LESS 1936) AND NOT(CMAKE_CXX_SIMULATE_VERSION))
       set_property(SOURCE ${ASM_SOURCES} APPEND PROPERTY COMPILE_OPTIONS "/quiet")
     endif()
 
     if(BOOST_CONTEXT_ARCHITECTURE STREQUAL i386)
       set_property(SOURCE ${ASM_SOURCES} APPEND PROPERTY COMPILE_OPTIONS "/safeseh")
     endif()
-  endif()
 
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set_property(SOURCE ${ASM_SOURCES} APPEND PROPERTY COMPILE_OPTIONS "-x" "assembler-with-cpp")
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set_property(SOURCE ${ASM_SOURCES} APPEND PROPERTY COMPILE_OPTIONS "-Wno-unused-command-line-argument")
-  endif()
+  else() # masm
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      set_property(SOURCE ${ASM_SOURCES} APPEND PROPERTY COMPILE_OPTIONS "-x" "assembler-with-cpp")
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      set_property(SOURCE ${ASM_SOURCES} APPEND PROPERTY COMPILE_OPTIONS "-Wno-unused-command-line-argument")
+    endif()
+  endif() # masm
 
   enable_language(${ASM_LANGUAGE})
   set_source_files_properties(${ASM_SOURCES} PROPERTIES LANGUAGE ${ASM_LANGUAGE})


### PR DESCRIPTION
PR for #293

Put `if (GNU/Clang)` into the MASM's `else` clause since `Clang-CL` validates positive at `CMAKE_CXX_COMPILER_ID STREQUAL "Clang"` while also having `MSVC` frontend for compile options and utilising `ML` masm assembler.

UPD: `clang-cl` `/quiet` support has been dropped due to [inability to know real version for sure](https://github.com/boostorg/context/issues/293#issuecomment-2676320713).
Side (weird) _fix_ for `/quiet` flag being passed on `MSVC_VERSION: 1936` despite Visual Studio Enterprise 2019 **Version 16.11.35**:

<details><summary>Dropping context</summary>

- Visual Studio Enterprise 2019 **Version 16.11.35**
- (Microsoft (R) Macro Assembler (x64) Version 14.29.30154.0)
- `message(STATUS "MSVC_VERSION: ${MSVC_VERSION}")` = `-- MSVC_VERSION: 1936` [report](https://github.com/boostorg/context/issues/293#issuecomment-2676274529)
- despite [doc](https://learn.microsoft.com/en-us/cpp/assembler/masm/ml-and-ml64-command-line-reference?view=msvc-170#:~:text=Suppresses%20%27Assembling%27%20message.%20Available%20in%20Visual%20Studio%2017.6%20and%20later.) says that: `/quiet` Suppresses 'Assembling' message. Available in **Visual Studio 17.6** and later.
Looks like CMake gives wrong `MSVC_VERSION` for `clang-cl`.

</details>

### Tested
On MS Windows with CMake with next compilers: `MSVC`, msys2/mingw64/`GCC`, msys2/clang64/`Clang`, `Clang-CL` (chocolatey install)