### PR TITLE
Fix compile failure with clang-cl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,7 +189,7 @@ if(BOOST_CONTEXT_IMPLEMENTATION STREQUAL "fcontext")
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set_property(SOURCE ${ASM_SOURCES} APPEND PROPERTY COMPILE_OPTIONS "-x" "assembler-with-cpp")
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT MSVC)
     set_property(SOURCE ${ASM_SOURCES} APPEND PROPERTY COMPILE_OPTIONS "-Wno-unused-command-line-argument")
   endif()
 


### PR DESCRIPTION
clang-cl uses `masm` which does not understand GNU compile options. 

```
Microsoft (R) Macro Assembler (x64) Version 14.43.34810.0
Copyright (C) Microsoft Corporation.  All rights reserved.

MASM : fatal error A1013:invalid numerical command-line argument : /W
```

This change prevents that from happening.