### PR TITLE
Remove Ubuntu 20.04 build from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15 ]
+        os: [ ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15 ]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
The Ubuntu 20.04 image on GitHub Actions has been unavailable since 2025-04-15. See <https://github.com/actions/runner-images/issues/11101> for more information on the deprecation and removal.

Therefore all build jobs that use the Ubuntu 20.04 runner image of GHA will fail and have to be replaced or removed.

Also see <https://github.com/boostorg/context/actions/runs/14540788005/job/40798186788> for an example for a failing build on `ubuntu-20.04`. It fails with the error message:

> This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101