### PR TITLE
restore exception state after destruction of fiber

### DIFF
--- a/include/boost/context/fiber_fcontext.hpp
+++ b/include/boost/context/fiber_fcontext.hpp
@@ -344,6 +344,8 @@ public:
 
     ~fiber() {
         if ( BOOST_UNLIKELY( nullptr != fctx_) ) {
+            detail::manage_exception_state exstate;
+            boost::ignore_unused(exstate);
             detail::ontop_fcontext(
 #if defined(BOOST_NO_CXX14_STD_EXCHANGE)
                     detail::exchange( fctx_, nullptr),


### PR DESCRIPTION
In the destructor of fiber its context can be loaded. The exception state saved in `resume()`/`resume_with()` can be restored during stack unwinding after a `forced_unwind` exception is thrown, which is caught afterwards, i.e. the exception state becomes corrupted.

This patch ensures that the correct exception state is restored before the destructor of the fiber returns.

Fixes #302.