### PR TITLE
fix build of ontop_sparc64_sysv_elf_gas.S

### DIFF
--- a/src/asm/ontop_sparc64_sysv_elf_gas.S
+++ b/src/asm/ontop_sparc64_sysv_elf_gas.S
@@ -45,6 +45,6 @@ ontop_fcontext:
 
 	jmpl %o2, %g0
 	 nop
-.size	jump_fcontext,.-jump_fcontext
+.size	ontop_fcontext,.-ontop_fcontext
 # Mark that we don't need executable stack.
 .section .note.GNU-stack,"",%progbits


### PR DESCRIPTION
Fix the symbol names used for .size.

It seems that this line was copy pasted from the "jump" implementation without adjusting the symbol name.