### PR TITLE
[CMAKE] CYGWIN: set correct binfmt and abi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ list(APPEND CMAKE_MODULE_PATH ${boost_context_SOURCE_DIR}/cmake)
 
 ## Binary format
 
-if(WIN32)
+if(WIN32 OR CYGWIN)
   set(_default_binfmt pe)
 elseif(APPLE)
   set(_default_binfmt mach-o)
@@ -31,7 +31,7 @@ math(EXPR _bits "${CMAKE_SIZEOF_VOID_P}*8")
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^[Aa][Rr][Mm]" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
   set(_default_abi aapcs)
-elseif(WIN32)
+elseif(WIN32 OR CYGWIN)
   set(_default_abi ms)
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^mips")
   if(_bits EQUAL 32)


### PR DESCRIPTION
Compiling on CYGWIN prints this error:
```
[  4%] Building ASM-ATT object libs/context/CMakeFiles/boost_context.dir/src/asm/make_x86_64_sysv_elf_gas.S.o
/usr/bin/as: unrecognized option `-x'
make[2]: *** [libs/context/CMakeFiles/boost_context.dir/build.make:78: libs/context/CMakeFiles/boost_context.dir/src/asm/make_x86_64_sysv_elf_gas.S.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:3961: libs/context/CMakeFiles/boost_context.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```
This PR fixes the right assembly sources to build because sysv and elf are nonsense on CYGWIN.
After this patch, it correctly searches `make_x86_64_ms_pe_gas.asm`, although it still raises an error because unrecognized `-x` option.

Since the changes in this patch are quite obvious, I hope that they could be included into the upcoming 1.89.0 release of boost.