### PR TITLE
[AArch64][BTI] Add BTI hint + GNU property to fcontext trampolines 

### DIFF
--- a/src/asm/jump_arm64_aapcs_elf_gas.S
+++ b/src/asm/jump_arm64_aapcs_elf_gas.S
@@ -53,11 +53,29 @@
 
 .file "jump_arm64_aapcs_elf_gas.S"
 .text
+#if defined(__ARM_FEATURE_BTI_DEFAULT) && (__ARM_FEATURE_BTI_DEFAULT == 1)
+/* Mark this object as requiring BTI, enabling the linker to set BTI on the output */
+    .pushsection .note.gnu.property, "a", %note
+    .p2align 3
+    .long 4                      /* namesz */
+    .long 16                     /* descsz (16 bytes) */
+    .long 5                      /* type = NT_GNU_PROPERTY_TYPE_0 */
+    .asciz "GNU"
+    .p2align 3
+    .long 0xc0000000             /* GNU_PROPERTY_AARCH64_FEATURE_1_AND */
+    .long 4                      /* datasz = 4 */
+    .long 1                      /* GNU_PROPERTY_AARCH64_FEATURE_1_BTI */
+    .long 0                      /* pad to 8-byte alignment */
+    .popsection
+#endif
 .align  2
 .global jump_fcontext
 .hidden jump_fcontext
 .type   jump_fcontext, %function
 jump_fcontext:
+#if defined(__ARM_FEATURE_BTI_DEFAULT) && (__ARM_FEATURE_BTI_DEFAULT == 1)
+    hint    #34                    /* bti c: valid indirect-entry target */
+#endif
     # prepare stack for GP + FPU
     sub  sp, sp, #0xb0
 

--- a/src/asm/make_arm64_aapcs_elf_gas.S
+++ b/src/asm/make_arm64_aapcs_elf_gas.S
@@ -53,11 +53,29 @@
 
 .file "make_arm64_aapcs_elf_gas.S"
 .text
+#if defined(__ARM_FEATURE_BTI_DEFAULT) && (__ARM_FEATURE_BTI_DEFAULT == 1)
+/* Mark this object as requiring BTI, enabling the linker to set BTI on the output */
+    .pushsection .note.gnu.property, "a", %note
+    .p2align 3
+    .long 4                      /* namesz */
+    .long 16                     /* descsz (16 bytes) */
+    .long 5                      /* type = NT_GNU_PROPERTY_TYPE_0 */
+    .asciz "GNU"
+    .p2align 3
+    .long 0xc0000000             /* GNU_PROPERTY_AARCH64_FEATURE_1_AND */
+    .long 4                      /* datasz = 4 */
+    .long 1                      /* GNU_PROPERTY_AARCH64_FEATURE_1_BTI */
+    .long 0                      /* pad to 8-byte alignment */
+    .popsection
+#endif
 .align  2
 .global make_fcontext
 .hidden make_fcontext
 .type   make_fcontext, %function
 make_fcontext:
+#if defined(__ARM_FEATURE_BTI_DEFAULT) && (__ARM_FEATURE_BTI_DEFAULT == 1)
+    hint    #34    /* bti c */
+#endif
     # shift address in x0 (allocated stack) to lower 16 byte boundary
     and x0, x0, ~0xF
 

--- a/src/asm/ontop_arm64_aapcs_elf_gas.S
+++ b/src/asm/ontop_arm64_aapcs_elf_gas.S
@@ -53,11 +53,29 @@
 
 .file "ontop_arm64_aapcs_elf_gas.S"
 .text
+#if defined(__ARM_FEATURE_BTI_DEFAULT) && (__ARM_FEATURE_BTI_DEFAULT == 1)
+/* Mark this object as requiring BTI, enabling the linker to set BTI on the output */
+    .pushsection .note.gnu.property, "a", %note
+    .p2align 3
+    .long 4                      /* namesz */
+    .long 16                     /* descsz (16 bytes) */
+    .long 5                      /* type = NT_GNU_PROPERTY_TYPE_0 */
+    .asciz "GNU"
+    .p2align 3
+    .long 0xc0000000             /* GNU_PROPERTY_AARCH64_FEATURE_1_AND */
+    .long 4                      /* datasz = 4 */
+    .long 1                      /* GNU_PROPERTY_AARCH64_FEATURE_1_BTI */
+    .long 0                      /* pad to 8-byte alignment */
+    .popsection
+#endif
 .align  2
 .global ontop_fcontext
 .hidden ontop_fcontext
 .type   ontop_fcontext, %function
 ontop_fcontext:
+#if defined(__ARM_FEATURE_BTI_DEFAULT) && (__ARM_FEATURE_BTI_DEFAULT == 1)
+    hint    #34    /* bti c */
+#endif
     # prepare stack for GP + FPU
     sub  sp, sp, #0xb0
 


### PR DESCRIPTION
**Add BTI hint + GNU property to fcontext trampolines** 

The AArch64 fcontext trampolines (jump_fcontext, make_fcontext, ontop_fcontext) are indirect-entry-points. On BTI-enforcing systems they must begin with a BTI or the first resume can trap with SIGILL.

Insert `bti c` (hint #34) at each entry under `__ARM_FEATURE_BTI_DEFAULT`, and emit `GNU_PROPERTY_AARCH64_FEATURE_1_BTI` from each AArch64 assembly file so linkers map the DSO with PROT_BTI.

Scope: ELF/GAS AArch64 trampolines only; +4 bytes per entry

Fixes [#308](https://github.com/boostorg/context/issues/308)

Notes
- This change is orthogonal to the separate LLVM landing-pad ``bti j`` [issue #149267](https://github.com/llvm/llvm-project/issues/149267); exception paths built with affected Clang toolchains will still require the upstream fix. 
