### PR TITLE
Fix cross-build ABI default to use deduced target architecture

### DIFF
--- a/boost-context-features.jam
+++ b/boost-context-features.jam
@@ -5,6 +5,7 @@
 
 import feature ;
 import os ;
+import property ;
 
 feature.feature segmented-stacks : on : optional propagated composite ;
 feature.compose <segmented-stacks>on : <define>BOOST_USE_SEGMENTED_STACKS ;
@@ -34,20 +35,35 @@ feature.feature binary-format
    ;
 feature.set-default binary-format : [ default_binary_format ] ;
 
-local rule default_abi ( )
+rule default_abi ( properties * )
 {
     local tmp = sysv ;
+    local arch = [ property.select <architecture> : $(properties) ] ;
 
-    # Avoid using "in" operator here: it returns true if its left
-    # part is empty, which happens e.g. with os.platform on
-    # some uncommon architectures.
-    if [ os.name ] = "NT" { tmp = ms ; }
+    if <target-os>windows in $(properties) { tmp = ms ; }
+    else if <target-os>cygwin in $(properties) { tmp = ms ; }
+    else if [ os.name ] = "NT" { tmp = ms ; }
     else if [ os.name ] = "CYGWIN" { tmp = ms ; }
-    else if [ os.platform ] = "ARM" { tmp = aapcs ; }
-    else if [ os.platform ] = "ARM64" { tmp = aapcs ; }
-    else if [ os.platform ] = "MIPS32" { tmp = o32 ; }
-    else if [ os.platform ] = "MIPS64" { tmp = n64 ; }
-    return $(tmp) ;
+    else if $(arch)
+    {
+        if <architecture>arm in $(properties) { tmp = aapcs ; }
+        else if <architecture>mips in $(properties)
+        {
+            if <address-model>64 in $(properties) { tmp = n64 ; }
+            else { tmp = o32 ; }
+        }
+    }
+    else
+    {
+        # Avoid using "in" operator here: it returns true if its left
+        # part is empty, which happens e.g. with os.platform on
+        # some uncommon architectures.
+        if [ os.platform ] = "ARM" { tmp = aapcs ; }
+        else if [ os.platform ] = "ARM64" { tmp = aapcs ; }
+        else if [ os.platform ] = "MIPS32" { tmp = o32 ; }
+        else if [ os.platform ] = "MIPS64" { tmp = n64 ; }
+    }
+    return <abi>$(tmp) ;
 }
 
 feature.feature abi
@@ -62,7 +78,7 @@ feature.feature abi
      x32
    : propagated
    ;
-feature.set-default abi : [ default_abi ] ;
+feature.set-default abi : sysv ;
 
 feature.feature context-impl
     : fcontext

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -14,10 +14,12 @@ import modules ;
 import os ;
 import toolset ;
 import config : requires ;
+import boost-context-features ;
 
 project
     : common-requirements <library>$(boost_dependencies)
     : requirements
+      <conditional>@boost-context-features.default_abi
       <target-os>windows,<architecture>arm,<address-model>64:<context-impl>winfib
       <target-os>windows:<define>_WIN32_WINNT=0x0601
       <target-os>linux,<toolset>gcc,<segmented-stacks>on:<cxxflags>-fsplit-stack


### PR DESCRIPTION
Greetings! 👋 

Conan.io maintainer here! We have kept Boost since version 1.6x and the current [Conan recipe](https://github.com/conan-io/conan-center-index/blob/master/recipes/boost/all/conanfile.py) is super complex to maintain. We have been investigating some tweaks to simplify it.

The [Context documentation](https://github.com/boostorg/context/blob/develop/doc/requirements.qbk#L22) still points to being explicit about b2 properties like `abi`, `address-model` and `binary-format`, but when considering using Conan, we can pre-configure all compiler flags needed, even when cross-building, so we could bypass b2 in most cases. 

In most cases, even when cross-building, we indeed only need to set `target-os` property and it will work, but Boost Context is different: it uses some conditions to pick the correct assembly file. However, the current implementation derives default ABI from the host CPU platform (os.platform), not from the deduced target <architecture>. Passing target-os does not correct this for macOS/Linux targets, which breaks cross-building cases, for instance, building from Mac M1 (aarch64) to x86_64. It's possible to see a mismatch when trying to build without explicit `abi` in b2:

> error: No best alternative for .../build/asm_sources with <abi>aapcs ... <architecture>x86 ... <binary-format>mach-o ...

No assembly is compiled: The `libboost_context` links only `fcontext.cpp` and fails with undefined `_make_fcontext`, `_jump_fcontext`, `_ontop_fcontext`.

This is a result of picking the system ABI aapcs, as I'm running on a Mac M1, but we actually wanted sysv. You can see the full build log with the error:  [boost-1.91.0-osx-x86_64-clang21-release-shared.log](https://github.com/user-attachments/files/29633940/boost-1.91.0-osx-x86_64-clang21-release-shared.log)

----

This PR makes b2 derive Context’s ABI from deduced target `<architecture>` (with host fallbacks for native builds), instead of always using the host CPU platform for ARM/MIPS: fixing cross-compiles like ARM Mac to x86_64 macOS without passing `abi=sysv` on the command line.

With these changes, Context picks the expected and correct files: `make_x86_64_sysv_macho_gas.S`, `jump_x86_64_sysv_macho_gas.S`, `ontop_x86_64_sysv_macho_gas.S` and links libboost_context, due its correct ABI deduction based on the archtecture which is listed in the compile flags, like `-arch x86_64`.

These changes were applied in Boost 1.91.0 to check, and it's working when cross-building from Mac M1 to Mac x86_64. Check the full build log: [boost-1.91.0-osx-x86_64-clang21-release-shared-patched.log](https://github.com/user-attachments/files/29634346/boost-1.91.0-osx-x86_64-clang21-release-shared-patched.log)

#### Steps to Reproduce

- Download Boost 1.91.0: https://archives.boost.io/release/1.91.0/source/boost_1_91_0.tar.bz2
- Build using b2 5.4.2 (pre-installed) with the following command line:

```
export CXXFLAGS="-arch x86_64 --target=x86_64-apple-darwin"
export LDFLAGS="-arch x86_64 --target=x86_64-apple-darwin"

b2 install --prefix=/tmp/boost-install toolset=clang link=shared target-os=darwin --with-context -j10
```
- My user-config.jam looks like:

```
import os ;
local cflags = [ os.environ CFLAGS ] ;
local cxxflags = [ os.environ CXXFLAGS ] ;
local ldflags = [ os.environ LDFLAGS ] ;
using clang :  : [ os.environ CXX ] : <compileflags>$(cflags) <cxxflags>$(cxxflags) <linkflags>$(ldflags) ;
```

All those variables are filled by Conan, but you can set them via environment variables as suggested.

----

This follows the same idea as https://github.com/boostorg/interprocess/pull/35 (prefer target properties over host), but for Context the critical change is tying ABI to deduced <architecture>, not to target-os on Darwin.

The CMake build in Context already gets this right: it sets ABI from `CMAKE_SYSTEM_PROCESSOR` (the cross-compile target), so x86_64 to sysv and the correct `*_x86_64_sysv_macho_*` asm files are chosen automatically.

Related to https://github.com/boostorg/context/issues/69 and https://github.com/boostorg/context/issues/139.

Regards!