### PR TITLE
Zero the frame-pointer terminator in aarch64 make_fcontext

### DIFF
--- a/src/asm/make_arm64_aapcs_elf_gas.S
+++ b/src/asm/make_arm64_aapcs_elf_gas.S
@@ -82,6 +82,11 @@ make_fcontext:
     # reserve space for context-data on context-stack
     sub  x0, x0, #0xb0
 
+    # zero the saved frame-pointer slot (x29, at offset 0x90 of the context block) so a fiber
+    # starts with a null frame-pointer terminator; a frame-pointer stack walker then stops at the
+    # fiber entry instead of following an uninitialized value off the stack.
+    str  xzr, [x0, #0x90]
+
     # third arg of make_fcontext() == address of context-function
     # store address as a PC to jump in
     str  x2, [x0, #0xa0]

--- a/src/asm/make_arm64_aapcs_macho_gas.S
+++ b/src/asm/make_arm64_aapcs_macho_gas.S
@@ -63,6 +63,11 @@ _make_fcontext:
     ; reserve space for context-data on context-stack
     sub  x0, x0, #0xb0
 
+    ; zero the saved frame-pointer slot (x29, at offset 0x90 of the context block) so a fiber
+    ; starts with a null frame-pointer terminator; a frame-pointer stack walker then stops at the
+    ; fiber entry instead of following an uninitialized value off the stack.
+    str  xzr, [x0, #0x90]
+
     ; third arg of make_fcontext() == address of context-function
     ; store address as a PC to jump in
     str  x2, [x0, #0xa0]

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -230,6 +230,10 @@ test-suite full :
 test-suite fc :
 [ run test_fcontext.cpp :
     : :
+    ]
+
+[ run test_fp_terminator.cpp :
+    : :
     ] ;
 
 explicit minimal ;

--- a/test/test_fp_terminator.cpp
+++ b/test/test_fp_terminator.cpp
@@ -1,0 +1,72 @@
+
+//          Copyright 2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+// Regression test: make_fcontext must leave a *null* frame-pointer terminator in the initial
+// context, so that a frame-pointer stack walker (macOS backtrace()/__thread_stack_pcs, sample,
+// lldb, crash reporters) stops at the fiber entry instead of following an uninitialized frame
+// pointer off the stack and crashing.
+//
+// We create a fiber on a stack that is poisoned with a pointer into a guard page and then, from
+// inside the fiber, walk the frame-pointer chain the way such a walker does (dereferencing each
+// frame). If make_fcontext leaves the terminator uninitialized, the walk reaches the poisoned
+// slot and faults in the guard page (test crashes). With the terminator zeroed, the walk stops
+// cleanly at the fiber entry and the test passes.
+//
+// Meaningful on arm64 (aapcs frame-pointer chain via x29); a no-op elsewhere.
+
+#include <boost/context/detail/fcontext.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+#if defined(__aarch64__) || defined(__arm64__)
+
+#include <cstddef>
+#include <cstdint>
+#include <sys/mman.h>
+
+namespace ctx = boost::context::detail;
+
+// Walk the frame-pointer chain from the current frame, dereferencing each frame like a naive
+// stack walker. A 0 terminator stops the walk; a poisoned (guard-page) terminator faults here.
+static void walk_fiber_fp_chain( ctx::transfer_t t) {
+    void ** fp = static_cast< void ** >( __builtin_frame_address( 0) );
+    for ( int i = 0; i < 100000 && fp != nullptr; ++i) {
+        void * saved_fp = fp[0];   // dereference: faults if fp points into the guard page
+        void * saved_lr = fp[1];
+        (void)saved_lr;
+        fp = static_cast< void ** >( saved_fp);
+    }
+    ctx::jump_fcontext( t.fctx, nullptr);
+}
+
+int main() {
+    const std::size_t size = 256 * 1024;
+    const std::size_t page = 16 * 1024;
+
+    char * base = static_cast< char * >(
+        ::mmap( nullptr, size + page, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0) );
+    BOOST_TEST( base != MAP_FAILED);
+    // guard page directly above the usable stack: any read past the stack top faults here
+    ::mprotect( base + size, page, PROT_NONE);
+
+    // Poison the whole usable stack with an (aligned) pointer into the guard page, so that an
+    // *uninitialized* frame-pointer terminator would send the walk into the guard.
+    const std::uintptr_t poison = reinterpret_cast< std::uintptr_t >( base + size + 64);
+    for ( std::size_t i = 0; i < size / sizeof( std::uintptr_t); ++i)
+        reinterpret_cast< std::uintptr_t * >( base)[ i] = poison;
+
+    ctx::fcontext_t fctx = ctx::make_fcontext( base + size, size, walk_fiber_fp_chain);
+    ctx::jump_fcontext( fctx, nullptr);   // crashes here if the terminator was not zeroed
+
+    // Reached only if the frame-pointer walk terminated cleanly at the fiber entry.
+    BOOST_TEST( true);
+    return boost::report_errors();
+}
+
+#else
+
+int main() { return 0; }
+
+#endif


### PR DESCRIPTION
On arm64, `make_fcontext` initializes the entry PC and the `finish` return address in the context block, but leaves the saved frame-pointer slot (x29, offset `0x90`) uninitialized. When a fiber runs, its bottom frame inherits whatever was in that memory (fiber stacks are generally not zeroed).

CFI-based unwinders (libunwind / `_Unwind_Backtrace`) are unaffected: they follow the unwind tables and stop at the fiber entry (cf. #321, which added `.eh_frame` info so libunwind terminates there). A frame-pointer walker, however (Apple's `backtrace()`/`__thread_stack_pcs`, `sample`, `lldb`, or OS crash reporters), chases the x29 chain, reads the uninitialized terminator, and follows it off the fiber stack. When that junk is an aligned, in-range, unmapped pointer, the walk dereferences it and the process crashes with `SIGSEGV`.

This surfaced in ClickHouse CI on macOS/arm64 after the sampling profilers were enabled there: the OS-level stack capture (`backtrace()`) faulted while the profiler sampled an allocation running on a Boost.Context fiber (https://github.com/ClickHouse/ClickHouse/issues/111579).

The fix zeroes the frame-pointer slot (`str xzr, [x0, #0x90]`) in both arm64 backends (`macho` and `elf`), so a fiber presents a null frame-pointer terminator and a walker stops cleanly at the fiber entry, like a real thread's bottom frame (`thread_start` leaves `fp = 0`). This complements #321: that made CFI unwinders terminate at `make_fcontext`; this does the same for frame-pointer walkers.

x86_64 is not affected and is left unchanged: it already stores `&finish` in the rbp slot (the `trampoline` uses it as the return address), so it has a defined terminator.

Test: `test/test_fp_terminator.cpp` runs a fiber on a poisoned stack backed by a guard page and walks the frame-pointer chain from inside the fiber. Without the fix the walk follows the uninitialized terminator into the guard and faults; with it, the walk stops at the null terminator. The test is guarded to arm64, so it also exercises Linux arm64 CI.
