### PR TITLE
Fix default ABI to allow using target-os instead of the default one

### DIFF
--- a/boost-context-features.jam
+++ b/boost-context-features.jam
@@ -58,8 +58,6 @@ rule default_abi ( properties * )
 
     if <target-os>windows in $(properties) { tmp = ms ; }
     else if <target-os>cygwin in $(properties) { tmp = ms ; }
-    else if [ os.name ] = "NT" { tmp = ms ; }
-    else if [ os.name ] = "CYGWIN" { tmp = ms ; }
     else if $(arch)
     {
         if <architecture>arm in $(properties) { tmp = aapcs ; }
@@ -74,7 +72,9 @@ rule default_abi ( properties * )
         # Avoid using "in" operator here: it returns true if its left
         # part is empty, which happens e.g. with os.platform on
         # some uncommon architectures.
-        if [ os.platform ] = "ARM" { tmp = aapcs ; }
+        if [ os.name ] = "NT" { tmp = ms ; }
+        else if [ os.name ] = "CYGWIN" { tmp = ms ; }
+        else if [ os.platform ] = "ARM" { tmp = aapcs ; }
         else if [ os.platform ] = "ARM64" { tmp = aapcs ; }
         else if [ os.platform ] = "MIPS32" { tmp = o32 ; }
         else if [ os.platform ] = "MIPS64" { tmp = n64 ; }


### PR DESCRIPTION
Greeting!

After merging PR #334 and #335, when doing a few new validations with Boost 1.92.0-RC1 (se https://lists.boost.org/archives/list/boost@lists.boost.org/thread/U7DDTRXFCNGGZA5XZ5H6ZL2MUEFH5OLM/) I found a missing scenario when cross-building OS, mainly on Windows as host and another OS (e.g. Android) as target. The previous PRs fixed Context's ABI and binary-format defaults to derive from the deduced  target (`<target-os>`/`<architecture>`) instead of the host platform, which is fine. However, the `default_abi()` still picks `ms` instead of the correct target ABI, even with `target-os`/`architecture` explicitly passed:

https://github.com/boostorg/context/blob/develop/boost-context-features.jam#L59

```
rule default_abi ( properties * )
{
    local tmp = sysv ;
    local arch = [ property.select <architecture> : $(properties) ] ;

    if <target-os>windows in $(properties) { tmp = ms ; }
    else if <target-os>cygwin in $(properties) { tmp = ms ; }
    else if [ os.name ] = "NT" { tmp = ms ; }
    else if [ os.name ] = "CYGWIN" { tmp = ms ; }
    else if $(arch)
    {
        if <architecture>arm in $(properties) { tmp = aapcs ; }
        else if <architecture>mips in $(properties)
        {
            if <address-model>64 in $(properties) { tmp = n64 ; }
            else { tmp = o32 ; }
        }
    }
```

So, in case I try to cross-compile Boost Context from Windows to Android, even passing explicit `target-os`, `abi`, `address-model`, and `architecture`, I still have the following error during the setup:

```
error: No best alternative for /C:/Users/uilia/.conan2/p/b/boostbeb40f0cea2a9/b/src/libs/context/build/asm_sources with <abi>ms <address-model>64 <architecture>arm <asynch-exceptions>off <binary-format>elf <boost.beast.allow-deprecated>on <boost.beast.separate-compilation>on <boost.cobalt.executor>any_io_executor <boost.cobalt.pmr>std <boost.locale.iconv>off <boost.locale.icu>off <context-impl>fcontext <coverage>off <debug-symbols>none <exception-handling>on <extern-c-nothrow>off <inlining>none <known-warnings>hide <link>shared <optimization>none <os>NT <pch>on <preserve-test-targets>on <profiling>off <python-debugging>off <relevant>abi <relevant>address-model <relevant>architecture <relevant>binary-format <relevant>toolset <rtti>on <runtime-debugging>none <runtime-link>none <stdlib>native <strip>off <target-os>android <testing.execute>on <threadapi>pthread <threading>multi <toolset-clang:platform>linux <toolset-clang:version>18 <toolset>clang <variant>release <vectorize>off <visibility>hidden <warnings-as-errors>off <warnings>on <x-deduced-platform>arm_64
    no match: <abi>aapcs <address-model>32 <architecture>arm <binary-format>elf <threading>multi <toolset>clang
    no match: <abi>aapcs <address-model>32 <architecture>arm <binary-format>elf <threading>multi <toolset>gcc
    no match: <abi>aapcs <address-model>32 <architecture>arm <binary-format>elf <threading>multi <toolset>qcc
    no match: <abi>aapcs <address-model>32 <architecture>arm <binary-format>mach-o <threading>multi <toolset>clang
    no match: <abi>aapcs <address-model>32 <architecture>arm <binary-format>mach-o <threading>multi <toolset>darwin
    no match: <abi>aapcs <address-model>32 <architecture>arm <binary-format>pe <threading>multi <toolset>msvc
    no match: <abi>aapcs <address-model>64 <architecture>arm <binary-format>elf <threading>multi <toolset>clang
    no match: <abi>aapcs <address-model>64 <architecture>arm <binary-format>elf <threading>multi <toolset>gcc
    no match: <abi>aapcs <address-model>64 <architecture>arm <binary-format>mach-o <threading>multi <toolset>clang
    no match: <abi>aapcs <address-model>64 <architecture>arm <binary-format>mach-o <threading>multi <toolset>darwin
...
```

You can see my full build log with this error here: [boost-1.92.0.rc1-windows-android-context.log](https://github.com/user-attachments/files/30900394/boost-1.92.0.rc1-windows-android-context.log)

As `default_abi` is wired in as `<conditional>@boost-context-features.default_abi`, it overrides the explicit `abi=` on the command line too. So running `b2 ... target-os=android architecture=arm abi=aapcs ...` still fails the same way on a Windows host, and there's no command-line workaround.

This PR moves the `[ os.name ] = "NT"`/`"CYGWIN"` to mirror `default_binary_format()` structure. The host name is now consulted only when neither `<target-os>` nor `<architecture>` was part of the build request, so if a user passes it explicitly, the explicit one should prevail. 

With this change, Context picks `make_arm64_aapcs_elf_gas.S` / `jump_arm64_aapcs_elf_gas.S` / `ontop_arm64_aapcs_elf_gas.S` when cross-building from Windows to Android/arm64, same as it already does correctly when cross-building from macOS or Linux.

I built locally, again Windows -> Android, and now I no longer have this error: [boost-1.92.0.rc1-windows-android-context-patched.log](https://github.com/user-attachments/files/30900541/boost-1.92.0.rc1-windows-android-context-patched.log)

#### Environment

Host OS: Windows 10
Target OS: Android
Compiler: Android (13691557, based on r522817d) clang version 18.0.4 (https://android.googlesource.com/toolchain/llvm-project d8003a456d14a3deb8054cdaa529ffbf02d9b262) - Target: 
Boost: 1.92.0-rc1

#### Steps to Reproduce

I used Conan initially, but I can reproduce when building from sources as well.

```
wget https://archives.boost.io/release/1.92.0/source/boost_1_92_0_rc1.zip
unzip boost_1_92_0_rc1.zip
cd boost_1_92_0/
bootstrap.bat

set "CXX=C:/Users/uilia/Development/android-ndk-r27d/toolchains/llvm/prebuilt/windows-x86_64/bin/aarch64-linux-android27-clang++.cmd"

b2 install target-os=android architecture=arm abi=aapcs binary-format=elf architecture=arm address-model=64 -d2 -q toolset=clang --layout=system
```

Note that as I'm cross-building, I have NDK 27d installed in my Windows, the official one from Android page. Android is just example, cross-building to Linux should result in the same. 

Tell me if you need further validation or information about the case. Regards! 